### PR TITLE
UP 1881 update key registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ $ openssl ecparam -genkey -name prime256v1 -noout | openssl ec -text -noout | gr
 store the keys persistently in the encrypted keystore.*
  
 ### X.509 Certificate Signing Requests
-The client creates X.509 Certificate Signing Requests (*CSR*) for the public keys of the devices it is managing.
-The CSR subject *Common Name* is the device UUID which corresponds to the public key.
-The subject *Organization* and *Country* can be set through the configuration.
+The client creates X.509 Certificate Signing Requests (*CSRs*) for the public keys of the devices it is managing.
+The *Common Name* of the CSR subject is the UUID associated with the public key.
+The values for the *Organization* and *Country* of the CSR subject can be set through the configuration.
 
 - add the following key-value pairs to your `config.json`:
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ UBIRCH_ENV=demo
  
 ### Use a SQL database to store the protocol context
 The `DSN` (*Data Source Name*) can be used to connect the client to a SQL database for storing the protocol context 
-(i.e. the encrypted keystore, key certificates and last signatures) persistently. If DSN is not set or empty, the 
+(i.e. the encrypted keystore and last signatures) persistently. If DSN is not set or empty, the 
 client will create a file `protocol.json` (and `protocol.json.bck`) locally in the working directory.
 
 If you want to use a SQL database instead of a local file, make sure to apply the 
@@ -243,7 +243,7 @@ The docker image mounts the current directory (`$(pwd)`) into the */data* path t
 load the configuration file (if configuration is not set via environment variables), 
 and the TLS certificate and key files (if TLS is enabled). 
 If no DSN (database) is set in the configuration, the image stores the protocol context 
-(i.e. keystore, key certificates and last signatures) in this directory as well, 
+(i.e. keystore and last signatures) in this directory as well, 
 in which case the directory must be writable. 
 
 It is also possible to pass an absolute path instead of `$(pwd)`.
@@ -404,7 +404,7 @@ Then just enter the following two lines in your working directory:
     2020/04/14 13:40:54 1 known UUID(s)
     2020/04/14 13:40:54 UBIRCH backend "demo" environment
     2020/04/14 13:40:54 protocol context will be saved to file (protocol.json)
-    2020/04/14 13:40:54 loaded protocol context: 0 certificates, 0 signatures
+    2020/04/14 13:40:54 loaded protocol context: 0 signatures
     2020/04/14 13:40:54 starting HTTP service
     
     ```

--- a/main/client.go
+++ b/main/client.go
@@ -94,7 +94,7 @@ func getSignedCertificate(p *ExtendedProtocol, name string) ([]byte, error) {
 
 // submit a message to a backend service, such as the key-service or niomon.
 // returns the response status code, the response headers, the response body and encountered errors.
-func post(data []byte, url string, headers map[string]string) (int, http.Header, []byte, error) {
+func post(url string, data []byte, headers map[string]string) (int, []byte, http.Header, error) {
 	client := &http.Client{}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
@@ -115,5 +115,5 @@ func post(data []byte, url string, headers map[string]string) (int, http.Header,
 	defer resp.Body.Close()
 
 	respBodyBytes, err := ioutil.ReadAll(resp.Body)
-	return resp.StatusCode, resp.Header, respBodyBytes, err
+	return resp.StatusCode, respBodyBytes, resp.Header, err
 }

--- a/main/client.go
+++ b/main/client.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path/filepath"
 	"time"
 
 	"github.com/google/uuid"
@@ -115,7 +114,7 @@ func post(url string, data []byte, headers map[string]string) (int, []byte, http
 
 // request a devices public key at the ubirch identity service
 func requestPublicKeys(identityService string, id uuid.UUID) ([]SignedKeyRegistration, error) {
-	url := filepath.Join(identityService, "/api/keyService/v1/pubkey/current/hardwareId/", id.String())
+	url := identityService + "/api/keyService/v1/pubkey/current/hardwareId/" + id.String()
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve public key info: %v", err)

--- a/main/client.go
+++ b/main/client.go
@@ -78,8 +78,8 @@ func getSignedCertificate(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte) ([]
 	return json.Marshal(cert)
 }
 
-// post submits a message to a backend service.
-// returns the response status code, the response headers, the response body and encountered errors.
+// post submits a message to a backend service
+// returns the response status code, body and headers and encountered errors
 func post(url string, data []byte, headers map[string]string) (int, []byte, http.Header, error) {
 	client := &http.Client{}
 
@@ -104,10 +104,10 @@ func post(url string, data []byte, headers map[string]string) (int, []byte, http
 	return resp.StatusCode, respBodyBytes, resp.Header, err
 }
 
-// request a devices public keys at the ubirch identity service
+// requestPublicKeys requests a devices public keys at the identity service
 // returns a list of the retrieved public key certificates
-func requestPublicKeys(identityService string, id uuid.UUID) ([]SignedKeyRegistration, error) {
-	url := identityService + "/api/keyService/v1/pubkey/current/hardwareId/" + id.String()
+func requestPublicKeys(keyService string, id uuid.UUID) ([]SignedKeyRegistration, error) {
+	url := keyService + "/current/hardwareId/" + id.String()
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve public key info: %v", err)
@@ -136,8 +136,8 @@ func requestPublicKeys(identityService string, id uuid.UUID) ([]SignedKeyRegistr
 
 // isKeyRegistered sends a request to the identity service to determine
 // if a specified public key is registered for the specified UUID
-func isKeyRegistered(identityService string, id uuid.UUID, pubKey []byte) (bool, error) {
-	certs, err := requestPublicKeys(identityService, id)
+func isKeyRegistered(keyService string, id uuid.UUID, pubKey []byte) (bool, error) {
+	certs, err := requestPublicKeys(keyService, id)
 	if err != nil {
 		return false, err
 	}

--- a/main/client.go
+++ b/main/client.go
@@ -94,7 +94,7 @@ func getSignedCertificate(p *ExtendedProtocol, name string) ([]byte, error) {
 
 // submit a message to a backend service, such as the key-service or niomon.
 // returns the response status code, the response headers, the response body and encountered errors.
-func post(data []byte, url string, headers map[string]string) (int, map[string][]string, []byte, error) {
+func post(data []byte, url string, headers map[string]string) (int, http.Header, []byte, error) {
 	client := &http.Client{}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))

--- a/main/client.go
+++ b/main/client.go
@@ -44,14 +44,8 @@ type SignedKeyRegistration struct {
 
 // getSignedCertificate gets a self-signed JSON key registration for the public key
 // to be sent to the ubirch identity service
-func getSignedCertificate(p *ExtendedProtocol, name string) ([]byte, error) {
+func getSignedCertificate(p *ExtendedProtocol, name string, uid uuid.UUID) ([]byte, error) {
 	const timeFormat = "2006-01-02T15:04:05.000Z"
-
-	// get the UUID
-	uid, err := p.GetUUID(name)
-	if err != nil {
-		return nil, err
-	}
 
 	// get the key
 	pubKey, err := p.GetPublicKey(name)

--- a/main/config.go
+++ b/main/config.go
@@ -33,10 +33,9 @@ const (
 	DEMO_STAGE = "demo"
 	PROD_STAGE = "prod"
 
-	keyURL      = "https://key.%s.ubirch.com/api/keyService/v1/pubkey"
-	identityURL = "https://identity.%s.ubirch.com/api/certs/v1/csr/register"
+	identityURL = "https://identity.%s.ubirch.com/"
 	niomonURL   = "https://niomon.%s.ubirch.com/"
-	verifyURL   = "https://verify.%s.ubirch.com/api/upp"
+	verifyURL   = "https://verify.%s.ubirch.com/"
 
 	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]}
 	authFile = "auth.json"       // {UUID: [key, token]}
@@ -62,7 +61,6 @@ type Config struct {
 	CORS_Origins     []string          `json:"CORS_origins"`     // list of allowed origin hosts, defaults to ["*"]
 	Debug            bool              `json:"debug"`            // enable extended debug output, defaults to 'false'
 	SecretBytes      []byte            // the decoded key store secret
-	KeyService       string            // key service URL (set automatically)
 	IdentityService  string            // identity service URL (set automatically)
 	Niomon           string            // authentication service URL (set automatically)
 	VerifyService    string            // verification service URL (set automatically)
@@ -202,12 +200,6 @@ func (c *Config) setDefaultURLs() error {
 
 	log.Printf("UBIRCH backend \"%s\" environment", c.Env)
 
-	if c.KeyService == "" {
-		c.KeyService = fmt.Sprintf(keyURL, c.Env)
-	} else {
-		c.KeyService = strings.TrimSuffix(c.KeyService, "/mpack")
-	}
-
 	if c.IdentityService == "" {
 		c.IdentityService = fmt.Sprintf(identityURL, c.Env)
 	}
@@ -216,10 +208,9 @@ func (c *Config) setDefaultURLs() error {
 		c.VerifyService = fmt.Sprintf(verifyURL, c.Env)
 	}
 
-	log.Debugf(" - Key Service URL: %s", c.KeyService)
-	log.Debugf(" - Identity Service URL: %s", c.IdentityService)
-	log.Debugf(" - Authentication Service URL: %s", c.Niomon)
-	log.Debugf(" - Verification Service URL: %s", c.VerifyService)
+	log.Debugf(" - Identity Service: %s", c.IdentityService)
+	log.Debugf(" - Authentication Service: %s", c.Niomon)
+	log.Debugf(" - Verification Service: %s", c.VerifyService)
 
 	return nil
 }

--- a/main/config.go
+++ b/main/config.go
@@ -33,9 +33,9 @@ const (
 	DEMO_STAGE = "demo"
 	PROD_STAGE = "prod"
 
-	identityURL = "https://identity.%s.ubirch.com/"
-	niomonURL   = "https://niomon.%s.ubirch.com/"
-	verifyURL   = "https://verify.%s.ubirch.com/"
+	identityURL = "https://identity.%s.ubirch.com"
+	niomonURL   = "https://niomon.%s.ubirch.com"
+	verifyURL   = "https://verify.%s.ubirch.com"
 
 	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]}
 	authFile = "auth.json"       // {UUID: [key, token]}

--- a/main/config.go
+++ b/main/config.go
@@ -38,8 +38,8 @@ const (
 	niomonURL   = "https://niomon.%s.ubirch.com/"
 	verifyURL   = "https://verify.%s.ubirch.com/api/upp"
 
-	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]}
-	authFile = "auth.json"       // {UUID: [key, token]}
+	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]} (legacy)
+	authFile = "auth.json"       // {UUID: [key, token]} (legacy)
 
 	defaultTLSCertFile = "cert.pem"
 	defaultTLSKeyFile  = "key.pem"
@@ -47,18 +47,18 @@ const (
 
 // configuration of the device
 type Config struct {
-	Devices          map[string]string `json:"devices"`          // maps UUIDs to backend auth tokens
-	Secret           string            `json:"secret"`           // secret used to encrypt the key store
+	Devices          map[string]string `json:"devices"`          // maps UUIDs to backend auth tokens (mandatory)
+	Secret           string            `json:"secret"`           // secret used to encrypt the key store (mandatory)
 	Env              string            `json:"env"`              // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
 	DSN              string            `json:"DSN"`              // "data source name" for database connection
 	StaticKeys       bool              `json:"staticKeys"`       // disable dynamic key generation, defaults to 'false'
-	Keys             map[string]string `json:"keys"`             // maps UUIDs to injected keys
+	Keys             map[string]string `json:"keys"`             // maps UUIDs to injected private keys
 	CSR_Country      string            `json:"CSR_country"`      // subject country for public key Certificate Signing Requests
 	CSR_Organization string            `json:"CSR_organization"` // subject organization for public key Certificate Signing Requests
 	TLS              bool              `json:"TLS"`              // enable serving HTTPS endpoints, defaults to 'false'
 	TLS_CertFile     string            `json:"TLSCertFile"`      // filename of TLS certificate file name, defaults to "cert.pem"
 	TLS_KeyFile      string            `json:"TLSKeyFile"`       // filename of TLS key file name, defaults to "key.pem"
-	CORS             bool              `json:"CORS"`             // enable CORS, defaults to false
+	CORS             bool              `json:"CORS"`             // enable CORS, defaults to 'false'
 	CORS_Origins     []string          `json:"CORS_origins"`     // list of allowed origin hosts, defaults to ["*"]
 	Debug            bool              `json:"debug"`            // enable extended debug output, defaults to 'false'
 	SecretBytes      []byte            // the decoded key store secret

--- a/main/config_test.go
+++ b/main/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`)
+	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"SecretBytes":null,"IdentityService":"","Niomon":"","VerifyService":""}`)
 
 	config := &Config{}
 

--- a/main/config_test.go
+++ b/main/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"SecretBytes":null,"IdentityService":"","Niomon":"","VerifyService":""}`)
+	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`)
 
 	config := &Config{}
 

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -38,6 +38,7 @@ type ServerEndpoint struct {
 
 type HTTPMessage struct {
 	ID       uuid.UUID
+	Auth     []byte
 	Hash     Sha256Sum
 	Response chan HTTPResponse
 }
@@ -175,6 +176,7 @@ func (endpnt *ServerEndpoint) checkAuth(id uuid.UUID, authHeader string) error {
 
 func (endpnt *ServerEndpoint) handleRequest(w http.ResponseWriter, r *http.Request, isHash bool) {
 	var id uuid.UUID
+	var auth []byte
 	var err error
 
 	if endpnt.RequiresAuth {
@@ -188,6 +190,7 @@ func (endpnt *ServerEndpoint) handleRequest(w http.ResponseWriter, r *http.Reque
 			Error(w, err, http.StatusUnauthorized)
 			return
 		}
+		auth = []byte(XAuthToken(r))
 	}
 
 	hash, err := getHash(r, isHash)
@@ -200,7 +203,7 @@ func (endpnt *ServerEndpoint) handleRequest(w http.ResponseWriter, r *http.Reque
 	respChan := make(chan HTTPResponse)
 
 	// submit message for singing
-	endpnt.MessageHandler <- HTTPMessage{ID: id, Hash: hash, Response: respChan}
+	endpnt.MessageHandler <- HTTPMessage{ID: id, Auth: auth, Hash: hash, Response: respChan}
 
 	// wait for response from ubirch backend to be forwarded
 	forwardBackendResponse(w, respChan)

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -202,7 +202,7 @@ func (endpnt *ServerEndpoint) handleRequest(w http.ResponseWriter, r *http.Reque
 	// create HTTPMessage with individual response channel for each request
 	respChan := make(chan HTTPResponse)
 
-	// submit message for singing
+	// submit message for signing
 	endpnt.MessageHandler <- HTTPMessage{ID: id, Auth: auth, Hash: hash, Response: respChan}
 
 	// wait for response from ubirch backend to be forwarded

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -146,10 +146,10 @@ func getHash(r *http.Request, isHash bool) (Sha256Sum, error) {
 // blocks until response is received and forwards it to sender
 func forwardBackendResponse(w http.ResponseWriter, respChan chan HTTPResponse) {
 	resp := <-respChan
-	w.WriteHeader(resp.Code)
 	for k, v := range resp.Headers {
 		w.Header().Set(k, v[0])
 	}
+	w.WriteHeader(resp.Code)
 	_, err := w.Write(resp.Content)
 	if err != nil {
 		log.Errorf("unable to write response: %s", err)

--- a/main/main.go
+++ b/main/main.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 
 	"github.com/google/uuid"
@@ -44,10 +43,10 @@ func shutdown(cancel context.CancelFunc) {
 
 func main() {
 	const (
-		Version         = "v2.0.0"
-		Build           = "local"
-		configFileName  = "config.json"
-		contextFileName = "protocol.json"
+		Version     = "v2.0.0"
+		Build       = "local"
+		configFile  = "config.json"
+		contextFile = "protocol.json"
 	)
 
 	var configDir string
@@ -60,7 +59,7 @@ func main() {
 
 	// read configuration
 	conf := Config{}
-	err := conf.Load(configDir, configFileName)
+	err := conf.Load(configDir, configFile)
 	if err != nil {
 		log.Fatalf("ERROR: unable to load configuration: %s", err)
 	}
@@ -75,14 +74,7 @@ func main() {
 	p.Certificates = map[string][]byte{}
 	p.CSRs = map[string][]byte{}
 
-	var contextFile string
-	if conf.Env == PROD_STAGE {
-		contextFile = filepath.Join(configDir, contextFileName)
-	} else {
-		contextFile = filepath.Join(configDir, conf.Env+"_"+contextFileName)
-	}
-
-	err = p.Init(contextFile, conf.DSN, conf.Keys)
+	err = p.Init(configDir, contextFile, conf.DSN, conf.Keys)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/google/uuid"
@@ -43,10 +44,10 @@ func shutdown(cancel context.CancelFunc) {
 
 func main() {
 	const (
-		Version     = "v2.0.0"
-		Build       = "local"
-		configFile  = "config.json"
-		contextFile = "protocol.json"
+		Version         = "v2.0.0"
+		Build           = "local"
+		configFileName  = "config.json"
+		contextFileName = "protocol.json"
 	)
 
 	var configDir string
@@ -59,7 +60,7 @@ func main() {
 
 	// read configuration
 	conf := Config{}
-	err := conf.Load(configDir, configFile)
+	err := conf.Load(configDir, configFileName)
 	if err != nil {
 		log.Fatalf("ERROR: unable to load configuration: %s", err)
 	}
@@ -74,7 +75,14 @@ func main() {
 	p.Certificates = map[string][]byte{}
 	p.CSRs = map[string][]byte{}
 
-	err = p.Init(configDir, contextFile, conf.DSN, conf.Keys)
+	var contextFile string
+	if conf.Env == PROD_STAGE {
+		contextFile = filepath.Join(configDir, contextFileName)
+	} else {
+		contextFile = filepath.Join(configDir, conf.Env+"_"+contextFileName)
+	}
+
+	err = p.Init(contextFile, conf.DSN, conf.Keys)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -71,6 +71,7 @@ func main() {
 		Names:    map[string]uuid.UUID{},
 	}
 	p.Signatures = map[uuid.UUID][]byte{}
+	p.CSRs = map[string][]byte{}
 
 	err = p.Init(configDir, contextFile, conf.DSN, conf.Keys)
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -71,7 +71,6 @@ func main() {
 		Names:    map[string]uuid.UUID{},
 	}
 	p.Signatures = map[uuid.UUID][]byte{}
-	p.CSRs = map[string][]byte{}
 
 	err = p.Init(configDir, contextFile, conf.DSN, conf.Keys)
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -88,12 +88,12 @@ func main() {
 	go shutdown(cancel)
 
 	// set up HTTP server
-	httpServer := HTTPServer{}
-	httpServer.Init(conf.Env)
-	if conf.TLS {
-		httpServer.SetUpTLS(conf.TLS_CertFile, conf.TLS_KeyFile)
+	httpServer := HTTPServer{
+		router:   NewRouter(),
+		certFile: conf.TLS_CertFile,
+		keyFile:  conf.TLS_KeyFile,
 	}
-	if conf.CORS && ENV != PROD_STAGE { // never enable CORS on production stage
+	if conf.CORS && conf.Env != PROD_STAGE { // never enable CORS on production stage
 		httpServer.SetUpCORS(conf.CORS_Origins)
 	}
 
@@ -127,7 +127,7 @@ func main() {
 
 	// start HTTP server
 	g.Go(func() error {
-		return httpServer.Serve(ctx)
+		return httpServer.Serve(ctx, conf.TLS)
 	})
 
 	//wait until all function calls from the Go method have returned

--- a/main/main.go
+++ b/main/main.go
@@ -71,8 +71,6 @@ func main() {
 		Names:    map[string]uuid.UUID{},
 	}
 	p.Signatures = map[uuid.UUID][]byte{}
-	p.Certificates = map[string][]byte{}
-	p.CSRs = map[string][]byte{}
 
 	err = p.Init(configDir, contextFile, conf.DSN, conf.Keys)
 	if err != nil {

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -33,7 +33,6 @@ import (
 
 type ExtendedProtocol struct {
 	ubirch.Protocol
-	CSRs        map[string][]byte
 	db          Database
 	contextFile string
 }
@@ -60,8 +59,8 @@ func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, k
 		return fmt.Errorf("unable to load protocol context: %v", err)
 	}
 
-	if len(p.Signatures) != 0 || len(p.CSRs) != 0 {
-		log.Printf("loaded existing protocol context: %d signatures, %d CSRs", len(p.Signatures), len(p.CSRs))
+	if len(p.Signatures) != 0 {
+		log.Printf("loaded existing protocol context: %d signatures", len(p.Signatures))
 	}
 
 	if keys != nil {

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
@@ -39,7 +40,7 @@ type ExtendedProtocol struct {
 }
 
 // INIT sets keys in crypto context and automatically updates keystore in persistent storage
-func (p *ExtendedProtocol) Init(contextFile string, dsn string, keys map[string]string) error {
+func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, keys map[string]string) error {
 	// check if we want to use a database as persistent storage
 	if dsn != "" {
 		// use the database
@@ -50,7 +51,7 @@ func (p *ExtendedProtocol) Init(contextFile string, dsn string, keys map[string]
 		p.db = db
 		log.Printf("protocol context will be saved to database")
 	} else {
-		p.contextFile = contextFile
+		p.contextFile = filepath.Join(configDir, filename)
 		log.Printf("protocol context will be saved to file: %s", p.contextFile)
 	}
 

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -33,6 +33,7 @@ import (
 
 type ExtendedProtocol struct {
 	ubirch.Protocol
+	CSRs        map[string][]byte
 	db          Database
 	contextFile string
 }
@@ -53,12 +54,15 @@ func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, k
 		log.Printf("protocol context will be saved to file: %s", p.contextFile)
 	}
 
-	// try to read an existing protocol context from persistent storage (keystore, last signatures, key certificates)
+	// try to read an existing protocol context from persistent storage (keystore, last signatures, CSRs)
 	err := p.LoadContext()
 	if err != nil {
 		return fmt.Errorf("unable to load protocol context: %v", err)
 	}
-	log.Printf("loaded existing protocol context: %d signatures", len(p.Signatures))
+
+	if len(p.Signatures) != 0 || len(p.CSRs) != 0 {
+		log.Printf("loaded existing protocol context: %d signatures, %d CSRs", len(p.Signatures), len(p.CSRs))
+	}
 
 	if keys != nil {
 		// inject keys from configuration to keystore
@@ -80,7 +84,7 @@ func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, k
 		// update keystore in persistent storage
 		err = p.PersistContext()
 		if err != nil {
-			return fmt.Errorf("unable to store key pairs: %v", err)
+			return fmt.Errorf("unable to store keys: %v", err)
 		}
 	}
 	return nil

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/google/uuid"
@@ -40,7 +39,7 @@ type ExtendedProtocol struct {
 }
 
 // INIT sets keys in crypto context and automatically updates keystore in persistent storage
-func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, keys map[string]string) error {
+func (p *ExtendedProtocol) Init(contextFile string, dsn string, keys map[string]string) error {
 	// check if we want to use a database as persistent storage
 	if dsn != "" {
 		// use the database
@@ -51,7 +50,7 @@ func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, k
 		p.db = db
 		log.Printf("protocol context will be saved to database")
 	} else {
-		p.contextFile = filepath.Join(configDir, filename)
+		p.contextFile = contextFile
 		log.Printf("protocol context will be saved to file: %s", p.contextFile)
 	}
 

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -73,7 +73,7 @@ func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, k
 			if err != nil {
 				return fmt.Errorf("unable to decode private key string for %s: %v, string was: %s", name, err, key)
 			}
-			err = p.Crypto.SetKey(name, uid, keyBytes)
+			err = p.SetKey(name, uid, keyBytes)
 			if err != nil {
 				return fmt.Errorf("unable to insert private key to protocol context: %v", err)
 			}

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -33,10 +33,8 @@ import (
 
 type ExtendedProtocol struct {
 	ubirch.Protocol
-	Certificates map[string][]byte
-	CSRs         map[string][]byte
-	db           Database
-	contextFile  string
+	db          Database
+	contextFile string
 }
 
 // INIT sets keys in crypto context and automatically updates keystore in persistent storage
@@ -60,7 +58,7 @@ func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, k
 	if err != nil {
 		return fmt.Errorf("unable to load protocol context: %v", err)
 	}
-	log.Printf("loaded existing protocol context: %d certificates, %d signatures", len(p.Certificates), len(p.Signatures))
+	log.Printf("loaded existing protocol context: %d signatures", len(p.Signatures))
 
 	if keys != nil {
 		// inject keys from configuration to keystore

--- a/main/signer.go
+++ b/main/signer.go
@@ -37,7 +37,7 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 			name := uid.String()
 
 			// check if there is a known signing key for UUID
-			if !p.Crypto.PrivateKeyExists(name) {
+			if !p.PrivateKeyExists(name) {
 				if conf.StaticKeys {
 					msg.Response <- HTTPErrorResponse(http.StatusUnauthorized, fmt.Sprintf("dynamic key generation is disabled and there is no injected signing key for UUID %s", name))
 					continue
@@ -45,7 +45,7 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 
 				// if dynamic key generation is enabled generate new key pair
 				log.Printf("%s: generating new key pair", name)
-				err := p.Crypto.GenerateKey(name, uid)
+				err := p.GenerateKey(name, uid)
 				if err != nil {
 					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, fmt.Sprintf("failed to generate new key pair for UUID %s: %v", name, err))
 					continue

--- a/main/signer.go
+++ b/main/signer.go
@@ -166,11 +166,12 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 			}
 
 			extendedResponse, err := json.Marshal(map[string][]byte{"hash": hash[:], "upp": upp, "response": respBody})
-			if err == nil {
-				respHeaders = map[string][]string{"Content-Type": {"application/json"}}
-			} else {
+			if err != nil {
 				log.Warnf("error serializing extended response: %v", err)
 				extendedResponse = respBody
+			} else {
+				respHeaders.Del("Content-Length")
+				respHeaders.Set("Content-Type", "application/json")
 			}
 			msg.Response <- HTTPResponse{Code: respCode, Headers: respHeaders, Content: extendedResponse}
 

--- a/main/signer.go
+++ b/main/signer.go
@@ -164,7 +164,7 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 			respCode, respBody, respHeaders, err := post(authService, upp, map[string]string{
 				"x-ubirch-hardware-id": name,
 				"x-ubirch-auth-type":   "ubirch",
-				"x-ubirch-credential":  base64.StdEncoding.EncodeToString([]byte(conf.Devices[name])),
+				"x-ubirch-credential":  base64.StdEncoding.EncodeToString(msg.Auth),
 			})
 			if err != nil {
 				msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error sending UPP to backend: %v", err))

--- a/main/signer.go
+++ b/main/signer.go
@@ -136,11 +136,10 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 				// submit a X.509 Certificate Signing Request for the public key
 				err = submitCSR(p, conf.IdentityService, name, conf.CSR_Country, conf.CSR_Organization)
 				if err != nil {
-					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, fmt.Sprintf("%s: submitting CSR failed: %v", name, err))
-					continue
+					log.Errorf("%s: submitting CSR failed: %v", name, err)
+				} else {
+					registered[name] = true
 				}
-
-				registered[name] = true
 			}
 
 			// create a chained UPP

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -181,10 +181,10 @@ func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProto
 				msg.Response <- HTTPErrorResponse(code, fmt.Sprintf("verification of hash %s failed! %v", hashString, err))
 				continue
 			}
-
 			uppString := base64.StdEncoding.EncodeToString(upp)
 			log.Debugf("%s: retrieved UPP: %s (0x%s)", hashString, uppString, hex.EncodeToString(upp))
-			message := uppString
+
+			message := "ok"
 
 			uid, err := p.verifyUPP(conf.IdentityService, upp)
 			if err != nil {

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -88,7 +88,7 @@ func (p *ExtendedProtocol) verifyUPP(keyService string, upp []byte) (uuid.UUID, 
 
 	pubkey, err := p.GetPublicKey(name)
 	if err != nil {
-		log.Warn(err)
+		log.Warnf("couldn't get public key for %s from local context: %s", name, err)
 
 		pubkey, err = loadPublicKey(keyService, id)
 		if err != nil {
@@ -120,6 +120,7 @@ func (p *ExtendedProtocol) verifyUPP(keyService string, upp []byte) (uuid.UUID, 
 
 // loadPublicKey retrieves the first valid public key associated with a device from the identity service
 func loadPublicKey(keyService string, id uuid.UUID) ([]byte, error) {
+	log.Printf("requesting public key for %s from key service: %s", id.String(), keyService)
 	keys, err := requestPublicKeys(keyService, id)
 	if err != nil {
 		return nil, err
@@ -169,7 +170,7 @@ func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProto
 			headers := map[string][]string{"Content-Type": {"application/json"}}
 			response, err := json.Marshal(map[string]string{"uuid": uid.String(), "hash": hash64, "upp": upp64})
 			if err != nil {
-				log.Warnf("error serializing extended response: %s", err)
+				log.Errorf("error serializing extended response: %s", err)
 				headers = map[string][]string{"Content-Type": {"application/octet-stream"}}
 				response = upp
 			}


### PR DESCRIPTION
the identity service changed its behavior regarding key registration messages. if a device tries to register a key that already exists, the identity service responds with an error. For this reason, we need to check if the key is already registered at the identity service before sending the key registration message.