### PR TITLE
Add docker-compose file

### DIFF
--- a/contrib/docker-compose.yml
+++ b/contrib/docker-compose.yml
@@ -1,0 +1,12 @@
+# You can start this file with `docker-compose up -d`, inspect the logs with 
+# `docker-compose logs --tail 100 -f`, and stop the service with
+# `docker-compose down`
+version: '3.8'
+
+services:
+  client:
+    image: ubirch/ubirch-client:stable
+    volumes:
+    - ./:/data:rw
+    ports:
+    - 8080:8080


### PR DESCRIPTION
Docker compose is one standard way to manage docker services running on your host.
It serves a similar purpose like Makefiles, as it contains all required informations to
Get a docker-contained services running.