### PR TITLE
Add experimental windows support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ x86:
 
 arm:
 	cd main; GOOS=${GOOS} CGO_ENABLED=${CGO} GOARCH=arm64 go build ${LDFLAGS} -o ${EXECUTABLE} main
+	
+windows:
+	cd main; GOOS=windows CGO_ENABLED=${CGO} GOARCH=arm64 go build ${LDFLAGS} -o ${EXECUTABLE}.exe main
 
 docker.x86:
 	docker build --build-arg GOARCH=amd64 -t $(DOCKER_IMAGE) .


### PR DESCRIPTION
This is untested, but will result in a executable that will be able to
run under Windows, without the use of WSL or Docker and
virtualization.