### PR TITLE
add support for additional platforms

### DIFF
--- a/.dockeringnore
+++ b/.dockeringnore
@@ -1,0 +1,10 @@
+.dockerignore
+Dockerfile
+
+.git
+.gitignore
+
+Makefile
+build/
+
+.github

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,39 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Push events to matching semver tags, i.e. v1.0.0, v20.15.10
+
+jobs:
+  tagged-release:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          make binaries
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          #draft: true
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: AButler/upload-release-assets@v2.0
+        with:
+          files: 'build/*'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,8 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+build/
 main/main
-main/ubirch-client
-main/ubirch-client-arm
-main/ubirch-client-x86
 *.bck
 
 /venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM golang:1.13 AS builder
+FROM golang:1.15 AS builder
 COPY . /app
 ARG GOARCH=amd64
+ARG GOARM=7
 WORKDIR /app/main
 RUN \
     CGO_ENABLED=0 \
     GOOS=linux \
     GOPROXY=https://proxy.golang.org,direct \
-    go build -o main .
+    go build -trimpath -ldflags="-buildid= -s -w -linkmode external -extldflags -static" -o main .
 
 
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
     CGO_ENABLED=0 \
     GOOS=linux \
     GOPROXY=https://proxy.golang.org,direct \
-    go build -trimpath -ldflags="-buildid= -s -w -linkmode external -extldflags -static" -o main .
+    go build -trimpath -ldflags="-buildid= -s -w" -o main .
 
 
 FROM scratch

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 
 NAME=ubirch-client
 DOCKER_IMAGE=ubirch/$(NAME)
+DOCKER_TAG:=latest # name of the tag that will be used
+DOCKER_TAG_LATEST:=false # should the 'latest' also tag be updated?
 
 VERSION=$(shell git describe --tags --match 'v[0-9]*' --dirty='+d' --always)
 REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo +d; fi)
@@ -21,7 +23,7 @@ REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet 
 GO=go
 LDFLAGS=-ldflags "-buildid= -s -w -X main.Version=$(VERSION)"
 GO_BUILD=$(GO) build -tags="netgo" -trimpath $(LDFLAGS)
-DOCKER=docker
+DOCKER=DOCKER_CLI_EXPERIMENTAL=enabled docker
 UPX=upx --quiet --quiet
 
 binaries: build/$(NAME).linux_amd64
@@ -29,13 +31,56 @@ binaries: build/$(NAME).linux_arm
 binaries: build/$(NAME).linux_arm64
 binaries: build/$(NAME).windows_amd64.exe
 
-images: build/docker-$(NAME).tar
-images: build/docker-$(NAME)-arm.tar
+images: build/docker-$(NAME)-amd64.tar
+images: build/docker-$(NAME)-arm32v7.tar
+images: build/docker-$(NAME)-arm64v8.tar
 
 all: binaries images
 
 docker: docker.amd64
-docker: docker.arm
+docker: docker.arm32v7
+docker: docker.arm64v8
+
+# Oh boy, here we go..
+dockerhub: docker
+#   The manifest-tool is not able to work if the images are not already
+#   Pushed to a remote docker repository!
+#   We are also not able to set the architecture of the tags at this time,
+#   so they will be treated as AMD64 and clutter the tags list.
+	$(DOCKER) push $(DOCKER_IMAGE):amd64
+	$(DOCKER) push $(DOCKER_IMAGE):arm32v7
+	$(DOCKER) push $(DOCKER_IMAGE):arm64v8
+#   removing manifests is neccessary, otherwise the manifest-tool will
+#   get stuck with no way of creating new manifests with the same name as
+#   existing ones.
+	rm ~/.docker/manifests -rf
+#   First we create the new manifest, inserting all the tags into it.
+#   Note that their architecture will still be referred as "amd64" at
+#   this point.
+	$(DOCKER) manifest create $(DOCKER_IMAGE):$(DOCKER_TAG) \
+		$(DOCKER_IMAGE):amd64 \
+		$(DOCKER_IMAGE):arm32v7 \
+		$(DOCKER_IMAGE):arm64v8
+#   Now we can update the freshly created manifest, so the architecture
+#   of our custom image tags are correct.
+	$(DOCKER) manifest annotate --os=linux --arch=amd64 $(DOCKER_IMAGE):$(DOCKER_TAG) $(DOCKER_IMAGE):amd64
+	$(DOCKER) manifest annotate --os=linux --arch=arm --variant=v7 $(DOCKER_IMAGE):$(DOCKER_TAG) $(DOCKER_IMAGE):arm32v7
+	$(DOCKER) manifest annotate --os=linux --arch=arm64  --variant=v8 $(DOCKER_IMAGE):$(DOCKER_TAG) $(DOCKER_IMAGE):arm64v8
+#   Finally we push it, creating a new multi-arch tag on the dockerhub.
+	$(DOCKER) manifest push $(DOCKER_IMAGE):$(DOCKER_TAG)
+#   Do we also need to update the 'latest' tag?
+ifeq ($(DOCKER_TAG_LATEST), true)
+#   As we have no way of copying this manifest, we need to do it all
+#   over again.
+	$(DOCKER) manifest create $(DOCKER_IMAGE):latest \
+		$(DOCKER_IMAGE):amd64 \
+		$(DOCKER_IMAGE):arm32v7 \
+		$(DOCKER_IMAGE):arm64v8
+	$(DOCKER) manifest annotate --os=linux --arch=amd64 $(DOCKER_IMAGE):latest $(DOCKER_IMAGE):amd64
+	$(DOCKER) manifest annotate --os=linux --arch=arm --variant=v7 $(DOCKER_IMAGE):latest $(DOCKER_IMAGE):arm32v7
+	$(DOCKER) manifest annotate --os=linux --arch=arm64  --variant=v8 $(DOCKER_IMAGE):latest $(DOCKER_IMAGE):arm64v8
+	$(DOCKER) manifest push $(DOCKER_IMAGE):latest
+endif
 
 build:
 	mkdir -p build/
@@ -56,18 +101,24 @@ pack: binaries
 	$(UPX) build/*
 
 docker.amd64:
-	$(DOCKER) build --build-arg GOARCH=amd64 -t $(DOCKER_IMAGE):latest .
+	$(DOCKER) build --build-arg GOARCH=amd64 -t $(DOCKER_IMAGE):amd64 .
 
-docker.arm:
-	$(DOCKER) build --build-arg GOARCH=arm --build-arg GOARM=7 -t $(DOCKER_IMAGE):arm .
+docker.arm32v7:
+	$(DOCKER) build --build-arg GOARCH=arm --build-arg GOARM=7 -t $(DOCKER_IMAGE):arm32v7 .
 
-build/docker-$(NAME).tar: build docker-latest
-	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):latest
+docker.arm64v8:
+	$(DOCKER) build --build-arg GOARCH=arm64 -t $(DOCKER_IMAGE):arm64v8 .
 
-build/docker-$(NAME)-arm.tar: build docker-arm
-	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):arm
+build/docker-$(NAME)-amd64.tar: build docker.amd64
+	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):amd64
+
+build/docker-$(NAME)-arm32v7.tar: build docker.arm32v7
+	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):arm32v7
+
+build/docker-$(NAME)-arm64v8.tar: build docker.arm64v8
+	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):arm64v8
 
 clean:
 	rm -r build/
 
-.PHONY: all binaries clean pack docker docker.amd64 docker.arm
+.PHONY: all binaries clean pack docker docker.amd64 docker.arm32v7 docker.arm64v8

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,73 @@
-EXECUTABLE=ubirch-client
+# Copyright 2020 UBIRCH GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-GOOS=linux
-CGO=0
-DOCKER_IMAGE=ubirch/ubirch-client
-VERSION=`git describe --tags`
-BUILD=`date +%Y%m%d%H%M%S`
+NAME=ubirch-client
+DOCKER_IMAGE=ubirch/$(NAME)
 
-LDFLAGS=-ldflags "-X main.Version=${VERSION} -X main.Build=${BUILD}"
+VERSION=$(shell git describe --tags --match 'v[0-9]*' --dirty='+d' --always)
+REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo +d; fi)
 
-x86:
-	cd main; GOOS=${GOOS} CGO_ENABLED=${CGO} GOARCH=amd64 go build ${LDFLAGS} -o ${EXECUTABLE} main
+GO=go
+LDFLAGS=-ldflags "-buildid= -s -w -X main.Version=$(VERSION)"
+GO_BUILD=$(GO) build -tags="netgo" -trimpath $(LDFLAGS)
+DOCKER=docker
+UPX=upx --quiet --quiet
 
-arm:
-	cd main; GOOS=${GOOS} CGO_ENABLED=${CGO} GOARCH=arm64 go build ${LDFLAGS} -o ${EXECUTABLE} main
+binaries: build/$(NAME).linux_amd64
+binaries: build/$(NAME).linux_arm
+binaries: build/$(NAME).linux_arm64
+binaries: build/$(NAME).windows_amd64.exe
 
-docker.x86:
-	docker build --build-arg GOARCH=amd64 -t $(DOCKER_IMAGE) .
+images: build/docker-$(NAME).tar
+images: build/docker-$(NAME)-arm.tar
+
+all: binaries images
+
+docker: docker.amd64
+docker: docker.arm
+
+build:
+	mkdir -p build/
+
+build/$(NAME).linux_amd64: build
+	cd main; CGO=0 GOOS=linux GOARCH=amd64 $(GO_BUILD) -o ../$@ .
+
+build/$(NAME).linux_arm: build
+	cd main; CGO=0 GOOS=linux GOARCH=arm GOARM=7 $(GO_BUILD) -o ../$@ .
+
+build/$(NAME).linux_arm64: build
+	cd main; CGO=0 GOOS=linux GOARCH=arm64 $(GO_BUILD) -o ../$@ .
+
+build/$(NAME).windows_amd64.exe: build
+	cd main; CGO=0 GOOS=windows GOARCH=amd64 $(GO_BUILD) -o ../$@ .
+
+pack: binaries
+	$(UPX) build/*
+
+docker.amd64:
+	$(DOCKER) build --build-arg GOARCH=amd64 -t $(DOCKER_IMAGE):latest .
 
 docker.arm:
-	docker build --build-arg GOARCH=arm64 -t $(DOCKER_IMAGE):arm .
+	$(DOCKER) build --build-arg GOARCH=arm --build-arg GOARM=7 -t $(DOCKER_IMAGE):arm .
+
+build/docker-$(NAME).tar: build docker-latest
+	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):latest
+
+build/docker-$(NAME)-arm.tar: build docker-arm
+	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):arm
 
 clean:
-	rm -f main/${EXECUTABLE}
+	rm -r build/
 
-.PHONY: clean arm x86 docker.x86 docker.arm
+.PHONY: all binaries clean pack docker docker.amd64 docker.arm


### PR DESCRIPTION
Overhaul makefile to build additional binaries and raspberry-pi compatible docker images.
* Add automatic building and uploading of binaries during releases.
* Add tagged releases triggering a github release.
* Add optional support for binary packing.
* Bump golang version to 1.15.
* Strip local path names from binaries.

The Makefile was rewritten to help with automatic building of artifacts for github releases. For this reason, some new commands were added:
```shell
make all      # will create all available artifacts
make binaries # will create all supported binaries
make pack     # compresses the binaries to be much smaller (requires UPX installation)
make docker   # will create docker images for amd64 armv7 and arm64
make images   # will stores created images as artifacts
make clean    # will delete all artifacts

make dockerhub DOCKER_TAG=v1.0.0 # will tag a multi-arch image with the selected tag and upload it
                                 # to the dockerhub.
```

![image](https://user-images.githubusercontent.com/33927916/94358466-75bd3180-00a1-11eb-8c09-390f1677b2da.png)
