### PR TITLE
add tests on Pull requests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,24 @@
+name: Run tests on PR
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.15.x]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Test
+        run: |
+          cd main/
+          go test ./...


### PR DESCRIPTION
This PR enables the automated running of `go test ./...` for multiple go versions and operating systems.

Currently Go 1.15 is used to run tests on Ubuntu, and Windows, in order to validate that the project is building on all supported platforms.

**The tests are failing currently**, but this is not caused by this PR. Integration tests are trying to reference a config file which has to be manually created.

Because of that automated testing is currently broken.