### PR TITLE
Improve Multi-Arch support in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,14 @@ FROM golang:1.15 AS builder
 COPY . /app
 ARG GOARCH=amd64
 ARG GOARM=7
+ARG VERSION=devbuild
+ARG REVISION=0000000
 WORKDIR /app/main
 RUN \
     CGO_ENABLED=0 \
     GOOS=linux \
     GOPROXY=https://proxy.golang.org,direct \
-    go build -trimpath -ldflags="-buildid= -s -w" -o main .
+    go build -trimpath -ldflags "-buildid= -s -w -X main.Version=$VERSION -X main.Revision=$REVISION" -o main .
 
 
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.15 AS builder
+ARG GOVERSION=1.15
+FROM golang:$GOVERSION-alpine AS builder
 COPY . /app
 ARG GOARCH=amd64
 ARG GOARM=7

--- a/Makefile
+++ b/Makefile
@@ -12,113 +12,148 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-NAME=ubirch-client
-DOCKER_IMAGE=ubirch/$(NAME)
-DOCKER_TAG:=latest # name of the tag that will be used
-DOCKER_TAG_LATEST:=false # should the 'latest' also tag be updated?
+.DEFAULT_GOAL := build
+# This is a makefile for Go projects, version 1.0.0.
+# The following targets of the makefile are called by the CI automatically:
+# - lint:
+#   checks code for obvious errors and reports them to the developer
+# - build:
+#   builds the artifacts of this repository
+# - test:
+#   runs the defined tests, optionally generates a coverage report
+# - publish:
+#   publishes the built artifacts to a remote repository
+# - publish-branch:
+#   publishes the build artifacts, but tags them with the branch name,
+#   so they can be referenced for development.
 
-VERSION=$(shell git describe --tags --match 'v[0-9]*' --dirty='+d' --always)
-REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo +d; fi)
+NOW = $(shell date -u -Iminutes)
+VERSION = $(shell git describe --tags --match 'v[0-9]*' --dirty='-dirty' --always)
+REVISION = $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo -dirty; fi)
+CURRENT_BRANCH = $(shell git branch --show-current |tr -cd '[:alnum:]-.')
 
-GO=go
-LDFLAGS=-ldflags "-buildid= -s -w -X main.Version=$(VERSION)"
-GO_BUILD=$(GO) build -tags="netgo" -trimpath $(LDFLAGS)
-DOCKER=DOCKER_CLI_EXPERIMENTAL=enabled docker
+NAME := ubirch-client
+SRC_URL = https://gitlab.com/ubirch/ubirch-client-go.git
+IMAGE_REPO := docker.io/ubirch/$(NAME)
+IMAGE_TAG := $(VERSION)
+IMAGE_ARCHS := amd64 arm arm64 386 # supported architectures
+
+GO = go
+GO_VERSION := 1.15
+LDFLAGS = -ldflags "-buildid= -s -w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)"
+GO_BUILD = $(GO) build -tags="netgo" -trimpath $(LDFLAGS)
 UPX=upx --quiet --quiet
+DOCKER = DOCKER_CLI_EXPERIMENTAL=enabled DOCKER_BUILDKIT=1 docker
+GO_LINTER_IMAGE = golangci/golangci-lint:v1.32.1
+THISDIR = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
-binaries: build/$(NAME).linux_amd64
-binaries: build/$(NAME).linux_arm
-binaries: build/$(NAME).linux_arm64
-binaries: build/$(NAME).windows_amd64.exe
+.PHONY: lint
+lint:
+	@# we supress echoing the command, so every output line
+	@# can be considered a linting error. 
+	@$(DOCKER) run --rm -v $(THISDIR):/app:ro -w /app $(GO_LINTER_IMAGE) golangci-lint run
 
-images: build/docker-$(NAME)-amd64.tar
-images: build/docker-$(NAME)-arm32v7.tar
-images: build/docker-$(NAME)-arm64v8.tar
+.PHONY: build
+build: binaries
 
-all: binaries images
-
-docker: docker.amd64
-docker: docker.arm32v7
-docker: docker.arm64v8
-
-# Oh boy, here we go..
-dockerhub: docker
-#   The manifest-tool is not able to work if the images are not already
-#   Pushed to a remote docker repository!
-#   We are also not able to set the architecture of the tags at this time,
-#   so they will be treated as AMD64 and clutter the tags list.
-	$(DOCKER) push $(DOCKER_IMAGE):amd64
-	$(DOCKER) push $(DOCKER_IMAGE):arm32v7
-	$(DOCKER) push $(DOCKER_IMAGE):arm64v8
-#   removing manifests is neccessary, otherwise the manifest-tool will
-#   get stuck with no way of creating new manifests with the same name as
-#   existing ones.
-	rm ~/.docker/manifests -rf
-#   First we create the new manifest, inserting all the tags into it.
-#   Note that their architecture will still be referred as "amd64" at
-#   this point.
-	$(DOCKER) manifest create $(DOCKER_IMAGE):$(DOCKER_TAG) \
-		$(DOCKER_IMAGE):amd64 \
-		$(DOCKER_IMAGE):arm32v7 \
-		$(DOCKER_IMAGE):arm64v8
-#   Now we can update the freshly created manifest, so the architecture
-#   of our custom image tags are correct.
-	$(DOCKER) manifest annotate --os=linux --arch=amd64 $(DOCKER_IMAGE):$(DOCKER_TAG) $(DOCKER_IMAGE):amd64
-	$(DOCKER) manifest annotate --os=linux --arch=arm --variant=v7 $(DOCKER_IMAGE):$(DOCKER_TAG) $(DOCKER_IMAGE):arm32v7
-	$(DOCKER) manifest annotate --os=linux --arch=arm64  --variant=v8 $(DOCKER_IMAGE):$(DOCKER_TAG) $(DOCKER_IMAGE):arm64v8
-#   Finally we push it, creating a new multi-arch tag on the dockerhub.
-	$(DOCKER) manifest push $(DOCKER_IMAGE):$(DOCKER_TAG)
-#   Do we also need to update the 'latest' tag?
-ifeq ($(DOCKER_TAG_LATEST), true)
-#   As we have no way of copying this manifest, we need to do it all
-#   over again.
-	$(DOCKER) manifest create $(DOCKER_IMAGE):latest \
-		$(DOCKER_IMAGE):amd64 \
-		$(DOCKER_IMAGE):arm32v7 \
-		$(DOCKER_IMAGE):arm64v8
-	$(DOCKER) manifest annotate --os=linux --arch=amd64 $(DOCKER_IMAGE):latest $(DOCKER_IMAGE):amd64
-	$(DOCKER) manifest annotate --os=linux --arch=arm --variant=v7 $(DOCKER_IMAGE):latest $(DOCKER_IMAGE):arm32v7
-	$(DOCKER) manifest annotate --os=linux --arch=arm64  --variant=v8 $(DOCKER_IMAGE):latest $(DOCKER_IMAGE):arm64v8
-	$(DOCKER) manifest push $(DOCKER_IMAGE):latest
-endif
-
-build:
-	mkdir -p build/
-
-build/$(NAME).linux_amd64: build
-	cd main; CGO=0 GOOS=linux GOARCH=amd64 $(GO_BUILD) -o ../$@ .
-
-build/$(NAME).linux_arm: build
-	cd main; CGO=0 GOOS=linux GOARCH=arm GOARM=7 $(GO_BUILD) -o ../$@ .
-
-build/$(NAME).linux_arm64: build
-	cd main; CGO=0 GOOS=linux GOARCH=arm64 $(GO_BUILD) -o ../$@ .
-
-build/$(NAME).windows_amd64.exe: build
-	cd main; CGO=0 GOOS=windows GOARCH=amd64 $(GO_BUILD) -o ../$@ .
+binaries: build/bin/$(NAME).linux_amd64
+binaries: build/bin/$(NAME).linux_arm
+binaries: build/bin/$(NAME).linux_arm64
+binaries: build/bin/$(NAME).linux_386
+binaries: build/bin/$(NAME).windows_amd64.exe
+build/bin/$(NAME).linux_amd64: build
+	CGO=0 GOOS=linux GOARCH=amd64 $(GO_BUILD) -o $@ .
+build/bin/$(NAME).linux_arm: build
+	CGO=0 GOOS=linux GOARCH=arm GOARM=7 $(GO_BUILD) -o $@ .
+build/bin/$(NAME).linux_arm64: build
+	CGO=0 GOOS=linux GOARCH=arm64 $(GO_BUILD) -o $@ .
+build/bin/$(NAME).linux_386: build
+	CGO=0 GOOS=linux GOARCH=386 $(GO_BUILD) -o $@ .
+build/bin/$(NAME).windows_amd64.exe: build
+	CGO=0 GOOS=windows GOARCH=amd64 $(GO_BUILD) -o $@ .
 
 pack: binaries
-	$(UPX) build/*
+	$(UPX) build/bin/*
 
-docker.amd64:
-	$(DOCKER) build --build-arg GOARCH=amd64 -t $(DOCKER_IMAGE):amd64 .
+.PHONY: test
+test:
+	$(DOCKER) run -t --rm -v $(THISDIR):/app -w /app golang:$(GO_VERSION) \
+	go test ./...
 
-docker.arm32v7:
-	$(DOCKER) build --build-arg GOARCH=arm --build-arg GOARM=7 -t $(DOCKER_IMAGE):arm32v7 .
+.PHONY: image 
+image:
+	$(DOCKER) build -t $(IMAGE_REPO):$(IMAGE_TAG) \
+		--build-arg="VERSION=$(VERSION)" \
+		--build-arg="REVISION=$(VERSION)" \
+		--build-arg="GOVERSION=$(REVISION)" \
+		--label="org.opencontainers.image.title=$(NAME)" \
+		--label="org.opencontainers.image.created=$(NOW)" \
+		--label="org.opencontainers.image.source=$(SRC_URL)" \
+		--label="org.opencontainers.image.version=$(VERSION)" \
+		--label="org.opencontainers.image.revision=$(REVISION)" .
 
-docker.arm64v8:
-	$(DOCKER) build --build-arg GOARCH=arm64 -t $(DOCKER_IMAGE):arm64v8 .
+# Publish publishes the built image.
+.PHONY: publish
+publish:
+# this would be the easy way:
+# (after depending on 'image' target)
+#	$(DOCKER) push $(IMAGE_REPO):$(IMAGE_TAG)
+# .. but we want multi-arch images:
+#	First we need to build the individual images
+	@for arch in $(IMAGE_ARCHS) ; do \
+		echo Building "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" ; \
+		$(DOCKER) build -t "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" \
+			--build-arg="GOARCH=$${arch}" \
+			--build-arg="VERSION=$(VERSION)" \
+			--label="org.opencontainers.image.title=$(NAME)" \
+			--label="org.opencontainers.image.created=$(NOW)" \
+			--label="org.opencontainers.image.source=$(SRC_URL)" \
+			--label="org.opencontainers.image.version=$(VERSION)" \
+			--label="org.opencontainers.image.revision=$(REVISION)" . \
+		; \
+	done
+#	The manifest-tool is not able to work if the images are not already
+#	Pushed to a remote docker repository!
+#	We are also not able to set the architecture of the tags at this time,
+#	so they will be treated as AMD64 and clutter the tags list.
+	@for arch in $(IMAGE_ARCHS) ; do \
+		echo Pushing "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" ; \
+		$(DOCKER) push "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" ;\
+	done
+#	removing manifests is neccessary, otherwise the manifest-tool will
+#	get stuck with no way of creating new manifests with the same name as
+#	existing ones.
+	rm ~/.docker/manifests -rf
+#	First we create the new manifest, inserting all the tags into it.
+#	Note that their architecture will still be referred as "amd64" at
+#	this point.
+	$(DOCKER) manifest create $(IMAGE_REPO):$(IMAGE_TAG) \
+		$(IMAGE_REPO):$(IMAGE_TAG)-amd64 \
+		$(IMAGE_REPO):$(IMAGE_TAG)-arm \
+		$(IMAGE_REPO):$(IMAGE_TAG)-arm64 \
+		$(IMAGE_REPO):$(IMAGE_TAG)-386
+#	Now we can update the freshly created manifest, so the architecture
+#	of our custom image tags are correct.
+	$(DOCKER) manifest annotate --os=linux --arch=amd64 \
+		$(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)-amd64
+	$(DOCKER) manifest annotate --os=linux --arch=arm --variant=v7 \
+		$(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)-arm
+	$(DOCKER) manifest annotate --os=linux --arch=arm64 --variant=v8 \
+		$(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)-arm64
+	$(DOCKER) manifest annotate --os=linux --arch=386 \
+		$(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)-386
+#	Finally we push it, creating a new multi-arch tag on the dockerhub.
+	$(DOCKER) manifest push $(IMAGE_REPO):$(IMAGE_TAG)
 
-build/docker-$(NAME)-amd64.tar: build docker.amd64
-	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):amd64
+.PHONY: publish-branch
+publish-branch: IMAGE_TAG=$(CURRENT_BRANCH)
+publish-branch: publish
 
-build/docker-$(NAME)-arm32v7.tar: build docker.arm32v7
-	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):arm32v7
-
-build/docker-$(NAME)-arm64v8.tar: build docker.arm64v8
-	$(DOCKER) image save --output=$@ $(DOCKER_IMAGE):arm64v8
-
+.PHONY: clean
 clean:
-	rm -r build/
-
-.PHONY: all binaries clean pack docker docker.amd64 docker.arm32v7 docker.arm64v8
+	rm -rf build/
+	$(DOCKER) image rm $(IMAGE_REPO):$(IMAGE_TAG) | true
+	@for arch in $(IMAGE_ARCHS) ; do \
+		$(DOCKER) image rm "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" | true ;\
+	done
+	echo "NOTE: some multi-arch images may not have been deleted by the target"

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,22 @@ publish:
 		$(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)-386
 #	Finally we push it, creating a new multi-arch tag on the dockerhub.
 	$(DOCKER) manifest push $(IMAGE_REPO):$(IMAGE_TAG)
+	
+
+tag-stable:
+#   As we have no way of copying this manifest, we need to do it all
+#   over again.
+	$(DOCKER) manifest create $(DOCKER_IMAGE):stable \
+		$(DOCKER_IMAGE):$(IMAGE_TAG)-amd64 \
+		$(DOCKER_IMAGE):$(IMAGE_TAG)-arm32v7 \
+		$(DOCKER_IMAGE):$(IMAGE_TAG)-arm64v8
+	$(DOCKER) manifest annotate --os=linux --arch=amd64 \
+		$(DOCKER_IMAGE):latest $(DOCKER_IMAGE):$(IMAGE_TAG)-amd64
+	$(DOCKER) manifest annotate --os=linux --arch=arm --variant=v7 \
+		$(DOCKER_IMAGE):latest $(DOCKER_IMAGE):$(IMAGE_TAG)-arm32v7
+	$(DOCKER) manifest annotate --os=linux --arch=arm64  --variant=v8 \
+		$(DOCKER_IMAGE):latest $(DOCKER_IMAGE):$(IMAGE_TAG)-arm64v8
+	$(DOCKER) manifest push $(DOCKER_IMAGE):stable
 
 .PHONY: publish-branch
 publish-branch: IMAGE_TAG=$(CURRENT_BRANCH)


### PR DESCRIPTION
This PR improves the existing multi-arch support.
In the past, we tagged images as stable by pulling them, tagging them and pushing them again. This does not work with multi-arch meta-tags, as they will only pull the version that is compatible with the currently used architecture.
As a result, only one architecture will be pushed towards the "latest" and "stable" tags.

This PR introduces one new target for building the stable tag, which will be called by the CI system.