### PR TITLE
UNG-1413 disable HTMLescape

### DIFF
--- a/main/config_test.go
+++ b/main/config_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 )
 
+const expectedConfig = `{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`
+
 func TestConfig(t *testing.T) {
-	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`)
+	configBytes := []byte(expectedConfig)
 
 	config := &Config{}
 
@@ -26,6 +28,8 @@ func TestConfig(t *testing.T) {
 	}
 
 	if !bytes.Equal(configBytes, jsonBytes) {
-		t.Errorf("Failed to serialize config to json: got %s expected %s", jsonBytes, configBytes)
+		t.Errorf("Failed to serialize config to json:\n"+
+			"- expected: %s\n"+
+			"-      got: %s", configBytes, jsonBytes)
 	}
 }

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -76,6 +76,14 @@ func getUUID(r *http.Request) (uuid.UUID, error) {
 	return id, nil
 }
 
+func JSONMarshal(v interface{}) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v)
+	return buffer.Bytes(), err
+}
+
 func getSortedCompactJSON(data []byte) ([]byte, error) {
 	var reqDump interface{}
 	var sortedCompactJson bytes.Buffer
@@ -86,7 +94,7 @@ func getSortedCompactJSON(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("unable to parse request body: %v", err)
 	}
 	// json.Marshal sorts the keys
-	sortedJson, err := json.Marshal(reqDump)
+	sortedJson, err := JSONMarshal(reqDump)
 	if err != nil {
 		return nil, fmt.Errorf("unable to serialize json object: %v", err)
 	}

--- a/main/http_server_test.go
+++ b/main/http_server_test.go
@@ -2,39 +2,27 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
 	"testing"
+)
+
+const (
+	testInputStr string = "{\n  \"id\": \"ba70ad8b-a564-4e58-9a3b-224ac0f0153f\",\n  \"ts\": 1613733623,\n  \"big\": 5102163654257655,\n  \"tpl\": [\n    801874468,\n    \"<f,c\",\n    66,\n    \"#_Ÿ1cb\",\n    19875,\n    \"#d\",\n    10,\n    \"}d$\\\\n'™!&#8482{ï\\\"e%7ü\"\n  ],\n  \"lst\": [\n    \"%20\",\n    \"5\",\n    \"6\",\n    \"_\",\n    \"_\",\n    \"c\",\n    \"Ï\",\n    \"D\"\n  ],\n  \"map\": {\n    \"Ë\": 11,\n    \"F\": 44464,\n    \"`\": 114,\n    \"\": 2033005546\n  },\n  \"str\": \" |8_;5Ï®d;F),$:bfä\\\\nÿd./A\\\"9(£C8< |Ï(Ä[äü2\\\\,fU+2122e07]{9Eë`_Df);C])¬ÿ:7 |9}DË+f?U+2122ïa(®%E:8£27&\\\\&ÜU+2122Äc+!0f!ü™4Äb4'`.ÄÄ0$ü;~Fc'8'8e0ÄAfEC<}\"\n}"
+	expOutputStr string = "{\"big\":5102163654257655,\"id\":\"ba70ad8b-a564-4e58-9a3b-224ac0f0153f\",\"lst\":[\"%20\",\"5\",\"6\",\"_\",\"_\",\"c\",\"Ï\",\"D\"],\"map\":{\"\":2033005546,\"F\":44464,\"`\":114,\"Ë\":11},\"str\":\" |8_;5Ï®d;F),$:bfä\\\\nÿd./A\\\"9(£C8< |Ï(Ä[äü2\\\\,fU+2122e07]{9Eë`_Df);C])¬ÿ:7 |9}DË+f?U+2122ïa(®%E:8£27&\\\\&ÜU+2122Äc+!0f!ü™4Äb4'`.ÄÄ0$ü;~Fc'8'8e0ÄAfEC<}\",\"tpl\":[801874468,\"<f,c\",66,\"#_Ÿ1cb\",19875,\"#d\",10,\"}d$\\\\n'™!&#8482{ï\\\"e%7ü\"],\"ts\":1613733623}"
+	expHash_64   string = "eOp3knHnkZ3Hu7q33OGl4EwC5hXrPK78STk76cMfI4Q="
 )
 
 func TestSortedCompactJson(t *testing.T) {
 	var tests = []struct {
 		testInput      []byte
 		expectedOutput []byte
+		expectedHash   string
 	}{
 		{
-			testInput: []byte(`{
-  "id": "xyz",
-  "ts": 1590666587,
-  "big": 781829421797092,
-  "lst_n": [
-    430954646,
-    229,
-    16978,
-    9
-  ],
-  "lst_l": [
-    "Ä",
-    "ö",
-    "F",
-    "c"
-  ],
-  "map": {
-    "A": 0,
-    "Ö": 38572,
-    "f": 49,
-    "ä": 2377016991
-  }
-}`),
-			expectedOutput: []byte(`{"big":781829421797092,"id":"xyz","lst_l":["Ä","ö","F","c"],"lst_n":[430954646,229,16978,9],"map":{"A":0,"f":49,"Ö":38572,"ä":2377016991},"ts":1590666587}`),
+			testInput:      []byte(testInputStr),
+			expectedOutput: []byte(expOutputStr),
+			expectedHash:   expHash_64,
 		},
 	}
 
@@ -43,10 +31,23 @@ func TestSortedCompactJson(t *testing.T) {
 		if err != nil {
 			t.Errorf("getSortedCompactJSON returned error: %v", err)
 		}
+
 		if !bytes.Equal(out, test.expectedOutput) {
 			t.Errorf("getSortedCompactJSON did not return expected output:\n"+
 				"- expected: %s\n"+
 				"-      got: %s", test.expectedOutput, out)
+		}
+
+		hash := sha256.Sum256(out)
+		expHash, err := base64.StdEncoding.DecodeString(test.expectedHash)
+		if err != nil {
+			t.Errorf("could not decode expected hash from base64 string: %v", err)
+		}
+
+		if !bytes.Equal(hash[:], expHash) {
+			t.Errorf("hash not as expected:\n"+
+				"- expected: %s\n"+
+				"-      got: %s", test.expectedHash, base64.StdEncoding.EncodeToString(hash[:]))
 		}
 	}
 }

--- a/simulation/bombard.py
+++ b/simulation/bombard.py
@@ -65,7 +65,7 @@ def to_64(hash_bytes: bytes) -> str:
 
 
 # generates a random JSON message
-def get_random_jsom_message() -> dict:
+def get_random_json_message() -> dict:
     msg = {
         "id": uuid,
         "ts": int(time.time()),
@@ -180,7 +180,7 @@ def send_verification_request(request_type: str, msg: dict, serialized: bytes, h
 print("\nsigning {} messages...\n".format(num * len(types)))
 for i in range(num):
     for t in types:
-        msg = get_random_jsom_message()
+        msg = get_random_json_message()
         serialized = serialize_msg(msg)
         hash_64 = to_64(hash_bytes(serialized))
         r = send_signing_request(t, msg, serialized, hash_64)

--- a/simulation/bombard.py
+++ b/simulation/bombard.py
@@ -13,7 +13,7 @@ if len(sys.argv) < 3:
     print("python3 ./bombard.py <UUID> <AUTH_TOKEN>")
     sys.exit()
 
-num = 50
+number_of_requests_per_type = 50
 uuid = sys.argv[1]
 auth = sys.argv[2]
 
@@ -177,8 +177,8 @@ def send_verification_request(request_type: str, msg: dict, serialized: bytes, h
     return send_request(url=url, headers=header, data=data)
 
 
-print("\nsigning {} messages...\n".format(num * len(types)))
-for i in range(num):
+print("\nsigning {} messages...\n".format(number_of_requests_per_type * len(types)))
+for i in range(number_of_requests_per_type):
     for t in types:
         msg = get_random_json_message()
         serialized = serialize_msg(msg)

--- a/simulation/bombard.py
+++ b/simulation/bombard.py
@@ -61,7 +61,7 @@ def hash_bytes(serialized: bytes) -> bytes:
 
 
 def to_64(hash_bytes: bytes) -> str:
-    return b2a_base64(hash_bytes).decode().rstrip('\n')
+    return b2a_base64(hash_bytes, newline=False).decode()
 
 
 # generates a random JSON message


### PR DESCRIPTION
The go client should not replace the special characters "<", ">", "&", U+2028, and U+2029 in a JSON data request when serializing it before generating the hash