### PR TITLE
UNG-1460 Support identities file

### DIFF
--- a/main/config.go
+++ b/main/config.go
@@ -97,12 +97,12 @@ func (c *Config) Load(configDir string, filename string) error {
 		log.SetFormatter(&log.TextFormatter{FullTimestamp: true, TimestampFormat: "2006-01-02 15:04:05.000 -0700"})
 	}
 
-	err = c.loadDeviceIdentitiesFile(configDir)
+	err = c.loadAuthMap(configDir) // legacy
 	if err != nil {
 		return err
 	}
 
-	err = c.loadAuthMap(configDir) // legacy
+	err = c.loadDeviceIdentitiesFile(configDir)
 	if err != nil {
 		return err
 	}

--- a/main/config.go
+++ b/main/config.go
@@ -128,11 +128,14 @@ func (c *Config) loadEnv() error {
 // LoadFile reads the configuration from a json file
 func (c *Config) loadFile(filename string) error {
 	log.Infof("loading configuration from file: %s", filename)
-	contextBytes, err := ioutil.ReadFile(filename)
+
+	fileHandle, err := os.Open(filename)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(contextBytes, c)
+	defer fileHandle.Close()
+
+	return json.NewDecoder(fileHandle).Decode(c)
 }
 
 func (c *Config) checkMandatory() error {
@@ -251,13 +254,14 @@ func (c *Config) loadDeviceIdentitiesFile(configDir string) error {
 		return nil
 	}
 
-	identitiesBytes, err := ioutil.ReadFile(filepath.Join(configDir, identitiesFile))
+	fileHandle, err := os.Open(filepath.Join(configDir, identitiesFile))
 	if err != nil {
 		return err
 	}
+	defer fileHandle.Close()
 
-	var buffer []map[string]string
-	err = json.Unmarshal(identitiesBytes, &buffer)
+	var identities []map[string]string
+	err = json.NewDecoder(fileHandle).Decode(&identities)
 	if err != nil {
 		return err
 	}
@@ -266,7 +270,7 @@ func (c *Config) loadDeviceIdentitiesFile(configDir string) error {
 		c.Devices = make(map[string]string)
 	}
 
-	for _, identity := range buffer {
+	for _, identity := range identities {
 		c.Devices[identity["uuid"]] = identity["password"]
 	}
 

--- a/main/config.go
+++ b/main/config.go
@@ -41,7 +41,7 @@ const (
 	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]} (legacy)
 	authFile = "auth.json"       // {UUID: [key, token]} (legacy)
 
-	identitiesFile = "identities.json" // [{ "uuid": "e26713ef-1223-42a9-81c5-43d36ec163a3", "password": "<pw>" }]
+	identitiesFile = "identities.json" // [{ "uuid": "<uuid>", "password": "<auth>" }]
 
 	defaultTLSCertFile = "cert.pem"
 	defaultTLSKeyFile  = "key.pem"
@@ -242,11 +242,6 @@ func (c *Config) setDefaultURLs() error {
 
 	return nil
 }
-
-// loadAuthMap loads the auth map from the environment
-func (c *Config) loadAuthMap(configDir string) error {
-	var err error
-	var authMapBytes []byte
 
 // loadDeviceIdentitiesFile loads device identities from the identities JSON file.
 // Returns without error if file does not exist.

--- a/main/config.go
+++ b/main/config.go
@@ -41,6 +41,8 @@ const (
 	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]} (legacy)
 	authFile = "auth.json"       // {UUID: [key, token]} (legacy)
 
+	identitiesFile = "identities.json" // [{ "uuid": "e26713ef-1223-42a9-81c5-43d36ec163a3", "password": "<pw>" }]
+
 	defaultTLSCertFile = "cert.pem"
 	defaultTLSKeyFile  = "key.pem"
 )
@@ -95,11 +97,22 @@ func (c *Config) Load(configDir string, filename string) error {
 		log.SetFormatter(&log.TextFormatter{FullTimestamp: true, TimestampFormat: "2006-01-02 15:04:05.000 -0700"})
 	}
 
-	_ = c.loadAuthMap(configDir)
+	err = c.loadDeviceIdentitiesFile(configDir)
+	if err != nil {
+		return err
+	}
+
+	err = c.loadAuthMap(configDir) // legacy
+	if err != nil {
+		return err
+	}
+
 	err = c.checkMandatory()
 	if err != nil {
 		return err
 	}
+
+	// set defaults
 	c.setDefaultCSR()
 	c.setDefaultTLS(configDir)
 	c.setDefaultCORS()
@@ -235,10 +248,50 @@ func (c *Config) loadAuthMap(configDir string) error {
 	var err error
 	var authMapBytes []byte
 
+// loadDeviceIdentitiesFile loads device identities from the identities JSON file.
+// Returns without error if file does not exist.
+func (c *Config) loadDeviceIdentitiesFile(configDir string) error {
+	// if file does not exist, return right away
+	if _, err := os.Stat(identitiesFile); os.IsNotExist(err) {
+		return nil
+	}
+
+	identitiesBytes, err := ioutil.ReadFile(filepath.Join(configDir, identitiesFile))
+	if err != nil {
+		return err
+	}
+
+	var buffer []map[string]string
+	err = json.Unmarshal(identitiesBytes, &buffer)
+	if err != nil {
+		return err
+	}
+
+	if c.Devices == nil {
+		c.Devices = make(map[string]string)
+	}
+
+	for _, identity := range buffer {
+		c.Devices[identity["uuid"]] = identity["password"]
+	}
+
+	return nil
+}
+
+// loadAuthMap loads the auth map from the environment >> legacy <<
+// Returns without error if neither env variable nor file exists.
+func (c *Config) loadAuthMap(configDir string) error {
+	var err error
+	var authMapBytes []byte
+
 	authMap := os.Getenv(authEnv)
 	if authMap != "" {
 		authMapBytes = []byte(authMap)
 	} else {
+		// if file does not exist, return
+		if _, err := os.Stat(authFile); os.IsNotExist(err) {
+			return nil
+		}
 		authMapBytes, err = ioutil.ReadFile(filepath.Join(configDir, authFile))
 		if err != nil {
 			return err

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -86,6 +86,11 @@ func initDeviceKeys(p *ExtendedProtocol, conf Config) error {
 		}
 		name := uid.String()
 
+		// make sure device has an auth token
+		if auth == "" {
+			return fmt.Errorf("no auth token found for device \"%s\"", device)
+		}
+
 		// check if there is a known signing key for the UUID
 		if !p.PrivateKeyExists(name) {
 			if conf.StaticKeys {

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -82,7 +82,7 @@ func initDeviceKeys(p *ExtendedProtocol, conf Config) error {
 		// check if device name is a valid UUID
 		uid, err := uuid.Parse(device)
 		if err != nil {
-			return fmt.Errorf("unable to parse device name \"%s\" as UUID: %s", device, err)
+			return fmt.Errorf("invalid device name \"%s\" (not a UUID): %s", device, err)
 		}
 		name := uid.String()
 


### PR DESCRIPTION
**Added:**

Support for device identities JSON file. Client is now able to initialize device UUIDs and auth tokens from JSON file `identities.json`:
```
[
  {
    "uuid": "d16f1bfe-566f-4aa7-8262-1361d47c53fa",
    "password": "this is a password"
  },
  {
    "uuid": "5d99fa95-f7bc-44bc-bc98-39436d1244f6",
    "password": "this is a password"
  }
]
```
This is in addition to the standard config file.