### PR TITLE
[WIP] Rework verification service

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,10 +607,10 @@ and insignificant space characters were elided.
 
    ```json
     {
-    "hash": "CDUvtOIBnnZ8im/UXQn5G/q5EK9l2Bqy+HyMgSzPZoA=",
-    "requestID": "0f11686e-aee3-4e97-8d0d-793a0c31d969",
-    "response": "liPEEJ08eP8i80RBpdGFxjbUhv/EQCFZYYMaG0ZewKSXq11MieXAcQSSe4MD1DfQCoCiVsQMZFjFrn0afI1vR2u/bOYWGzaffm5/eHDH5VsgMso8uBMAxCAPEWhuruNOl40NeToMMdlpAAAAAAAAAAAAAAAAAAAAAMRA+IFgAugN6CY1xPSch1TwhFdac8yRA1QhPRXOhUt7rudrwrNv0NAEJGlLw1wUSpcSLmBFQaoRb9EezmYxmtF7iA==",
-    "upp": "liPEEFCxpbuDzUJRtnSzxxoFj8PEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxCAINS+04gGednyKb9RdCfkb+rkQr2XYGrL4fIyBLM9mgMRAIVlhgxobRl7ApJerXUyJ5cBxBJJ7gwPUN9AKgKJWxAxkWMWufRp8jW9Ha79s5hYbNp9+bn94cMflWyAyyjy4Ew=="
+      "hash": "CDUvtOIBnnZ8im/UXQn5G/q5EK9l2Bqy+HyMgSzPZoA=",
+      "requestID": "0f11686e-aee3-4e97-8d0d-793a0c31d969",
+      "response": "liPEEJ08eP8i80RBpdGFxjbUhv/EQCFZYYMaG0ZewKSXq11MieXAcQSSe4MD1DfQCoCiVsQMZFjFrn0afI1vR2u/bOYWGzaffm5/eHDH5VsgMso8uBMAxCAPEWhuruNOl40NeToMMdlpAAAAAAAAAAAAAAAAAAAAAMRA+IFgAugN6CY1xPSch1TwhFdac8yRA1QhPRXOhUt7rudrwrNv0NAEJGlLw1wUSpcSLmBFQaoRb9EezmYxmtF7iA==",
+      "upp": "liPEEFCxpbuDzUJRtnSzxxoFj8PEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxCAINS+04gGednyKb9RdCfkb+rkQr2XYGrL4fIyBLM9mgMRAIVlhgxobRl7ApJerXUyJ5cBxBJJ7gwPUN9AKgKJWxAxkWMWufRp8jW9Ha79s5hYbNp9+bn94cMflWyAyyjy4Ew=="
     }
    ```
    If you get a response code other than `200`, it means that something went wrong. To check the error message, decode

--- a/README.md
+++ b/README.md
@@ -433,8 +433,8 @@ backend, which is also a UPP:
 {
   "hash": "<the base64 encoded data hash>",
   "upp": "<the base64 encoded UPP containing the data hash that was sent to the ubirch backend by the client>",
-  "requestID": "<the base64 encoded request ID>",
-  "response": "<the base64 encoded backend response>"
+  "response": "<the base64 encoded backend response>",
+  "requestID": "<the request ID (standard hex string representation)>"
 }
 ```
 
@@ -546,7 +546,8 @@ and insignificant space characters were elided.
       "devices": {
         "<YOUR_UUID>": "<YOUR_AUTH_TOKEN>"
       },
-      "secret": "<YOUR_16_BYTE_SECRET(base64 encoded)>"
+      "secret": "<YOUR_16_BYTE_SECRET(base64 encoded)>",
+      "logTextFormat": true
     }
     ```
     - Replace `<YOUR_UUID>` with your UUID from step 1.i.
@@ -562,15 +563,15 @@ and insignificant space characters were elided.
     ```
    You should see a console output like this:
     ```console
-    INFO[2020-06-30 12:16:30.977 +0200] UBIRCH client (v2.0.0, build=local)
-    INFO[2020-06-30 12:16:30.977 +0200] loading configuration from file (config.json)
-    INFO[2020-06-30 12:16:30.977 +0200] 1 known UUID(s)
-    INFO[2020-06-30 12:16:30.977 +0200] UBIRCH backend "prod" environment
-    INFO[2020-06-30 12:16:30.977 +0200] protocol context will be saved to file: protocol.json
-    INFO[2020-06-30 12:16:31.142 +0200] generating new key pair for UUID 8a70ad8b-a564-4e58-9a3b-224ac0f0153f
-    INFO[2020-06-30 12:16:31.469 +0200] 8a70ad8b-a564-4e58-9a3b-224ac0f0153f: registering public key at key service: https://key.prod.ubirch.com/api/keyService/v1/pubkey
-    INFO[2020-06-30 12:16:31.584 +0200] 8a70ad8b-a564-4e58-9a3b-224ac0f0153f: submitting CSR to identity service: https://identity.prod.ubirch.com/api/certs/v1/csr/register
-    INFO[2020-06-30 12:16:32.842 +0200] starting HTTP service
+    {"level":"info","msg":"UBIRCH client (v2.0.0, build=local)","time":"2021-03-01T18:41:20+01:00"}
+    {"level":"info","msg":"loading configuration from file: config.json","time":"2021-03-01T18:41:20+01:00"}
+    INFO[2021-03-01 18:41:20.291 +0100] 1 known UUID(s)
+    INFO[2021-03-01 18:41:20.291 +0100] UBIRCH backend "prod" environment
+    INFO[2021-03-01 18:41:20.291 +0100] protocol context will be saved to file: protocol.json
+    INFO[2021-03-01 18:41:20.291 +0100] generating new key pair for UUID 50b1a5bb-83cd-4251-b674-b3c71a058fc3
+    INFO[2021-03-01 18:41:20.664 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: registering public key at key service: https://key.prod.ubirch.com/api/keyService/v1/pubkey
+    INFO[2021-03-01 18:41:21.755 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: submitting CSR to identity service: https://identity.prod.ubirch.com/api/certs/v1/csr/register
+    INFO[2021-03-01 18:41:22.130 +0100] starting HTTP service
     ```
    That means the client is running and ready!
 
@@ -588,14 +589,15 @@ and insignificant space characters were elided.
 
    Here is an example of how a request to the client would look like using `CURL`:
    ```console
-   curl -H "X-Auth-Token: <YOUR_AUTH_TOKEN>" -H "Content-Type: application/json" -d '{"id": "605b91b4-49be-4f17-93e7-f1b14384968f", "ts": 1585838578, "data": "1234567890"}' localhost:8080/<YOUR_UUID> -i -s
+   curl -H "X-Auth-Token: <YOUR_AUTH_TOKEN>" -H "Content-Type: application/json" -d '{"id": "50b1a5bb-83cd-4251-b674-b3c71a058fc3", "ts": 1614621028, "data": "1234567890"}' localhost:8080/<YOUR_UUID> -i -s
    ```
    > Insert `<YOUR_AUTH_TOKEN>` and `<YOUR_UUID>` and a request body with your own unique content to ensure a unique hash!
 
    When the client receives the request, the output should look like this:
-   ```console
-   INFO[2020-06-30 12:17:31.584 +0200] 8a70ad8b-a564-4e58-9a3b-224ac0f0153f: signing hash: bTawDQO7nnB+3h55/6VyQ+Tmd1RTV9R0cFcf7CRWzQQ=
-   ```
+    ```console
+    INFO[2021-03-01 18:52:59.471 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: hash: CDUvtOIBnnZ8im/UXQn5G/q5EK9l2Bqy+HyMgSzPZoA=
+    INFO[2021-03-01 18:53:00.313 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: request ID: 0f11686e-aee3-4e97-8d0d-793a0c31d969
+    ```
    > Take note of the hash!
 
    If your request was submitted, you'll get a `200` response code.
@@ -605,10 +607,10 @@ and insignificant space characters were elided.
 
    ```json
     {
-      "hash": "bTawDQO7nnB+3h55/6VyQ+Tmd1RTV9R0cFcf7CRWzQQ=",
-      "requestID": "7fZH8yVcT0apq4Pnu5sdVw==",
-      "response": "liPEEJ08eP8i80RBpdGFxjbUhv/EQPgwxioCe/xc+22gjjvULF32Q+zZNDosE0msmzyppKHihm2a7wb7g3VJoXg2UhpM4xS87kAapI+m+QRONig9bIkAgadtZXNzYWdlv3lvdXIgcmVxdWVzdCBoYXMgYmVlbiBzdWJtaXR0ZWTEQP/3P6UH0G8qY5t9bdSjroKVI4N5KScCHKJ9xsoHhesLLv9dCgdD0UoGvc/Mg9x0PGHKVoxKBwPs1v95+M+EQQQ=",
-      "upp": "liPEEPfutp5U60IAt/7nLuSggtLEQPgwxioCe/xc+22gjjvULF32Q+zZNDosE0msmzyppKHihm2a7wb7g3VJoXg2UhpM4xS87kAapI+m+QRONig9bIkAxCBtNrANA7uecH7eHnn/pXJD5OZ3VFNX1HRwVx/sJFbNBMRAZqKMnYa7nuyfmyV1dAUxwBvXG3fdZYUxyRE+mfeC/GWDwNXE4Tga5iauFfzOaULeNcUR2msAzwcL0FObMZaNaw=="
+    "hash": "CDUvtOIBnnZ8im/UXQn5G/q5EK9l2Bqy+HyMgSzPZoA=",
+    "requestID": "0f11686e-aee3-4e97-8d0d-793a0c31d969",
+    "response": "liPEEJ08eP8i80RBpdGFxjbUhv/EQCFZYYMaG0ZewKSXq11MieXAcQSSe4MD1DfQCoCiVsQMZFjFrn0afI1vR2u/bOYWGzaffm5/eHDH5VsgMso8uBMAxCAPEWhuruNOl40NeToMMdlpAAAAAAAAAAAAAAAAAAAAAMRA+IFgAugN6CY1xPSch1TwhFdac8yRA1QhPRXOhUt7rudrwrNv0NAEJGlLw1wUSpcSLmBFQaoRb9EezmYxmtF7iA==",
+    "upp": "liPEEFCxpbuDzUJRtnSzxxoFj8PEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxCAINS+04gGednyKb9RdCfkb+rkQr2XYGrL4fIyBLM9mgMRAIVlhgxobRl7ApJerXUyJ5cBxBJJ7gwPUN9AKgKJWxAxkWMWufRp8jW9Ha79s5hYbNp9+bn94cMflWyAyyjy4Ew=="
     }
    ```
    If you get a response code other than `200`, it means that something went wrong. To check the error message, decode

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the [releases](https://github.com/ubirch/ubirch-client-go/releases/latest)
 and pull it from Docker Hub using the latest release tag, i.e.:
 
 ```console
-$ docker pull ubirch/ubirch-client:v1.1.1
+$ docker pull ubirch/ubirch-client:v1.0.2
 ```
 
 [Jump to Quick Start](#quick-start)
@@ -345,8 +345,8 @@ UBIRCH_DEBUG=true
 To start the multi-arch Docker image on any system, run:
 
 ```console
-$ docker pull ubirch/ubirch-client:v1.1.1
-$ docker run -v $(pwd):/data -p <host_port>:8080 ubirch/ubirch-client:v1.1.1
+$ docker pull ubirch/ubirch-client:v1.0.2
+$ docker run -v $(pwd):/data -p <host_port>:8080 ubirch/ubirch-client:v1.0.2
 ```
 
 > replace `<host_port>` with the desired TCP network port on the host (e.g. `-p 8080:8080`)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ the [releases](https://github.com/ubirch/ubirch-client-go/releases/latest)
 and pull it from Docker Hub using the latest release tag, i.e.:
 
 ```console
-$ docker pull ubirch/ubirch-client:v1.0.2
+$ docker pull ubirch/ubirch-client:v1.1.1
 ```
 
 [Jump to Quick Start](#quick-start)
@@ -345,8 +345,8 @@ UBIRCH_DEBUG=true
 To start the multi-arch Docker image on any system, run:
 
 ```console
-$ docker pull ubirch/ubirch-client:v1.0.2
-$ docker run -v $(pwd):/data -p <host_port>:8080 ubirch/ubirch-client:v1.0.2
+$ docker pull ubirch/ubirch-client:v1.1.1
+$ docker run -v $(pwd):/data -p <host_port>:8080 ubirch/ubirch-client:v1.1.1
 ```
 
 > replace `<host_port>` with the desired TCP network port on the host (e.g. `-p 8080:8080`)

--- a/main/client.go
+++ b/main/client.go
@@ -155,5 +155,9 @@ func isKeyRegistered(keyService string, id uuid.UUID, pubKey []byte) (bool, erro
 }
 
 func httpFailed(StatusCode int) bool {
-	return !(StatusCode >= 200 && StatusCode < 300)
+	return !httpSuccess(StatusCode)
+}
+
+func httpSuccess(StatusCode int) bool {
+	return StatusCode >= 200 && StatusCode < 300
 }

--- a/main/client.go
+++ b/main/client.go
@@ -102,9 +102,9 @@ func post(url string, data []byte, headers map[string]string) (HTTPResponse, err
 
 	respBodyBytes, err := ioutil.ReadAll(resp.Body)
 	return HTTPResponse{
-		Code:    resp.StatusCode,
-		Headers: resp.Header,
-		Content: respBodyBytes,
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header,
+		Content:    respBodyBytes,
 	}, err
 }
 

--- a/main/config.go
+++ b/main/config.go
@@ -104,13 +104,13 @@ func (c *Config) Load(configDir string, filename string) error {
 
 // loadEnv reads the configuration from environment variables
 func (c *Config) loadEnv() error {
-	log.Print("loading configuration from environment variables")
+	log.Infof("loading configuration from environment variables")
 	return envconfig.Process("ubirch", c)
 }
 
 // LoadFile reads the configuration from a json file
 func (c *Config) loadFile(filename string) error {
-	log.Printf("loading configuration from file (%s)", filename)
+	log.Infof("loading configuration from file: %s", filename)
 	contextBytes, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err
@@ -124,7 +124,7 @@ func (c *Config) checkMandatory() error {
 			"It is mandatory to set at least one device UUID and auth token in the configuration.\n" +
 			"For more information take a look at the README under 'Configuration'.")
 	} else {
-		log.Printf("%d known UUID(s)", len(c.Devices))
+		log.Infof("%d known UUID(s)", len(c.Devices))
 		for name := range c.Devices {
 			log.Debugf(" - %s", name)
 		}
@@ -135,7 +135,7 @@ func (c *Config) checkMandatory() error {
 	}
 
 	if len(c.Keys) != 0 {
-		log.Printf("%d injected key(s)", len(c.Keys))
+		log.Infof("%d injected key(s)", len(c.Keys))
 	}
 
 	if c.StaticKeys {
@@ -198,7 +198,7 @@ func (c *Config) setDefaultURLs() error {
 		return fmt.Errorf("invalid UBIRCH backend environment: \"%s\"", c.Env)
 	}
 
-	log.Printf("UBIRCH backend \"%s\" environment", c.Env)
+	log.Infof("UBIRCH backend \"%s\" environment", c.Env)
 
 	if c.KeyService == "" {
 		c.KeyService = fmt.Sprintf(keyURL, c.Env)

--- a/main/config.go
+++ b/main/config.go
@@ -29,17 +29,20 @@ import (
 )
 
 const (
-	DEV_STAGE  = "dev"
-	DEV_UUID   = "9d3c78ff-22f3-4441-a5d1-85c636d486ff"
-	DEV_PUBKEY = "LnU8BkvGcZQPy5gWVUL+PHA0DP9dU61H8DBO8hZvTyI7lXIlG1/oruVMT7gS2nlZDK9QG+ugkRt/zTrdLrAYDA=="
+	DEV_STAGE        = "dev"
+	DEV_UUID         = "9d3c78ff-22f3-4441-a5d1-85c636d486ff"
+	DEV_PUBKEY_ECDSA = "LnU8BkvGcZQPy5gWVUL+PHA0DP9dU61H8DBO8hZvTyI7lXIlG1/oruVMT7gS2nlZDK9QG+ugkRt/zTrdLrAYDA=="
+	DEV_PUBKEY_EdDSA = "okA7krya3TZbPNEv8SDQIGR/hOppg/mLxMh+D0vozWY="
 
-	DEMO_STAGE  = "demo"
-	DEMO_UUID   = "07104235-1892-4020-9042-00003c94b60b"
-	DEMO_PUBKEY = "xm+iIomBRjR3QdvLJrGE1OBs3bAf8EI49FfgBriRk36n4RUYX+0smrYK8tZkl6Lhrt9lzjiUGrXGijRoVE+UjA=="
+	DEMO_STAGE        = "demo"
+	DEMO_UUID         = "07104235-1892-4020-9042-00003c94b60b"
+	DEMO_PUBKEY_ECDSA = "xm+iIomBRjR3QdvLJrGE1OBs3bAf8EI49FfgBriRk36n4RUYX+0smrYK8tZkl6Lhrt9lzjiUGrXGijRoVE+UjA=="
+	DEMO_PUBKEY_EdDSA = "Of93YysDTQ66bSGcL/GS6fJJFsmgJnKstJ/QURiq0lE="
 
-	PROD_STAGE  = "prod"
-	PROD_UUID   = "10b2e1a4-56b3-4fff-9ada-cc8c20f93016"
-	PROD_PUBKEY = "pJdYoJN0N3QTFMBVjZVQie1hhgumQVTy2kX9I7kXjSyoIl40EOa9MX24SBAABBV7xV2IFi1KWMnC1aLOIvOQjQ=="
+	PROD_STAGE        = "prod"
+	PROD_UUID         = "10b2e1a4-56b3-4fff-9ada-cc8c20f93016"
+	PROD_PUBKEY_ECDSA = "pJdYoJN0N3QTFMBVjZVQie1hhgumQVTy2kX9I7kXjSyoIl40EOa9MX24SBAABBV7xV2IFi1KWMnC1aLOIvOQjQ=="
+	PROD_PUBKEY_EdDSA = "74BIrQbAKFrwF3AJOBgwxGzsAl0B2GCF51pPAEHC5pA="
 
 	keyURL      = "https://key.%s.ubirch.com/api/keyService/v1/pubkey"
 	identityURL = "https://identity.%s.ubirch.com/api/certs/v1/csr/register"
@@ -86,13 +89,13 @@ type identity struct {
 
 type pubkey struct {
 	ECDSA string
-	EDDSA string
+	EdDSA string
 }
 
-var defaultServerIdentities = map[string]identity{ // todo add EDDSA keys
-	DEV_STAGE:  {UUID: DEV_UUID, PubKey: pubkey{ECDSA: DEV_PUBKEY}},
-	DEMO_STAGE: {UUID: DEMO_UUID, PubKey: pubkey{ECDSA: DEMO_PUBKEY}},
-	PROD_STAGE: {UUID: PROD_UUID, PubKey: pubkey{ECDSA: PROD_PUBKEY}},
+var defaultServerIdentities = map[string]identity{
+	DEV_STAGE:  {UUID: DEV_UUID, PubKey: pubkey{ECDSA: DEV_PUBKEY_ECDSA, EdDSA: DEV_PUBKEY_EdDSA}},
+	DEMO_STAGE: {UUID: DEMO_UUID, PubKey: pubkey{ECDSA: DEMO_PUBKEY_ECDSA, EdDSA: DEMO_PUBKEY_EdDSA}},
+	PROD_STAGE: {UUID: PROD_UUID, PubKey: pubkey{ECDSA: PROD_PUBKEY_ECDSA, EdDSA: PROD_PUBKEY_EdDSA}},
 }
 
 func (c *Config) Load(configDir string, filename string) error {
@@ -253,11 +256,9 @@ func (c *Config) setDefaultURLs() error {
 	log.Debugf(" - Verification Service: %s", c.VerifyService)
 
 	if c.ServerIdentity == (identity{}) {
-		log.Debugf("setting default server identity")
-
 		c.ServerIdentity.UUID = defaultServerIdentities[c.Env].UUID
 		c.ServerIdentity.PubKey.ECDSA = defaultServerIdentities[c.Env].PubKey.ECDSA
-		c.ServerIdentity.PubKey.EDDSA = defaultServerIdentities[c.Env].PubKey.EDDSA
+		c.ServerIdentity.PubKey.EdDSA = defaultServerIdentities[c.Env].PubKey.EdDSA
 	}
 
 	return nil

--- a/main/config.go
+++ b/main/config.go
@@ -67,7 +67,7 @@ type Config struct {
 	Keys             map[string]string `json:"keys"`             // maps UUIDs to injected private keys
 	CSR_Country      string            `json:"CSR_country"`      // subject country for public key Certificate Signing Requests
 	CSR_Organization string            `json:"CSR_organization"` // subject organization for public key Certificate Signing Requests
-	TCP_addr         string            `json:"TCP_addr"`         // the TCP address for the server to listen on, in the form "host:port", defaults to ":8080"
+	TCPaddr          string            `json:"TCP_addr"`         // the TCP address for the server to listen on, in the form "host:port", defaults to ":8080"
 	TLS              bool              `json:"TLS"`              // enable serving HTTPS endpoints, defaults to 'false'
 	TLS_CertFile     string            `json:"TLSCertFile"`      // filename of TLS certificate file name, defaults to "cert.pem"
 	TLS_KeyFile      string            `json:"TLSKeyFile"`       // filename of TLS key file name, defaults to "key.pem"
@@ -195,8 +195,8 @@ func (c *Config) setDefaultCSR() {
 }
 
 func (c *Config) setDefaultTLS(configDir string) {
-	if c.TCP_addr == "" {
-		c.TCP_addr = ":8080"
+	if c.TCPaddr == "" {
+		c.TCPaddr = ":8080"
 	}
 
 	if c.TLS {

--- a/main/config.go
+++ b/main/config.go
@@ -67,7 +67,7 @@ type Config struct {
 	Keys             map[string]string `json:"keys"`             // maps UUIDs to injected private keys
 	CSR_Country      string            `json:"CSR_country"`      // subject country for public key Certificate Signing Requests
 	CSR_Organization string            `json:"CSR_organization"` // subject organization for public key Certificate Signing Requests
-	TCPaddr          string            `json:"TCP_addr"`         // the TCP address for the server to listen on, in the form "host:port", defaults to ":8080"
+	TCP_addr         string            `json:"TCP_addr"`         // the TCP address for the server to listen on, in the form "host:port", defaults to ":8080"
 	TLS              bool              `json:"TLS"`              // enable serving HTTPS endpoints, defaults to 'false'
 	TLS_CertFile     string            `json:"TLSCertFile"`      // filename of TLS certificate file name, defaults to "cert.pem"
 	TLS_KeyFile      string            `json:"TLSKeyFile"`       // filename of TLS key file name, defaults to "key.pem"
@@ -195,8 +195,8 @@ func (c *Config) setDefaultCSR() {
 }
 
 func (c *Config) setDefaultTLS(configDir string) {
-	if c.TCPaddr == "" {
-		c.TCPaddr = ":8080"
+	if c.TCP_addr == "" {
+		c.TCP_addr = ":8080"
 	}
 
 	if c.TLS {

--- a/main/config_test.go
+++ b/main/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","serverIdentity":{"UUID":"","PubKey":{"ECDSA":"","EdDSA":""}},"DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCPaddr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`)
+	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","serverIdentity":{"UUID":"","PubKey":{"ECDSA":"","EdDSA":""}},"DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`)
 
 	config := &Config{}
 

--- a/main/config_test.go
+++ b/main/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`)
+	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","serverIdentity":{"UUID":"","PubKey":{"ECDSA":"","EdDSA":""}},"DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`)
 
 	config := &Config{}
 

--- a/main/config_test.go
+++ b/main/config_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","serverIdentity":{"UUID":"","PubKey":{"ECDSA":"","EdDSA":""}},"DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`)
+	configBytes := []byte(`{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","serverIdentity":{"UUID":"","PubKey":{"ECDSA":"","EdDSA":""}},"DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCPaddr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`)
 
 	config := &Config{}
 

--- a/main/go.mod
+++ b/main/go.mod
@@ -13,3 +13,7 @@ require (
 	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )
+
+replace (
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5 => ../../ubirch-protocol-go/ubirch
+)

--- a/main/go.mod
+++ b/main/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.3
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/main/go.mod
+++ b/main/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubirch/ubirch-client-go/main
 
-go 1.13
+go 1.16
 
 require (
 	github.com/go-chi/chi v4.1.0+incompatible
@@ -10,10 +10,6 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.0
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
-)
-
-replace (
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5 => ../../ubirch-protocol-go/ubirch
 )

--- a/main/go.mod
+++ b/main/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.0
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.1
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/main/go.mod
+++ b/main/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.2
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.3
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/main/go.mod
+++ b/main/go.mod
@@ -13,3 +13,5 @@ require (
 	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.1
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )
+
+replace github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.1 => ../../ubirch-protocol-go/ubirch

--- a/main/go.mod
+++ b/main/go.mod
@@ -10,8 +10,6 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.1
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.2
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )
-
-replace github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.1 => ../../ubirch-protocol-go/ubirch

--- a/main/go.sum
+++ b/main/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -24,8 +23,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IKw=
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5 h1:7sOjpGo+kBmvyOEEiQ6UqpqlLZzybdij3oxDz5uCSXM=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5/go.mod h1:nTqN+niHQNN5XLxMgd5MOD+yW9vBi9trYIj4vBuVi2Y=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.0 h1:F8skmGjeKxRqJOXjV//1xbVIvBBhQG1r+qmyKnYYcRQ=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.0/go.mod h1:nTqN+niHQNN5XLxMgd5MOD+yW9vBi9trYIj4vBuVi2Y=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/go.sum
+++ b/main/go.sum
@@ -23,8 +23,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IKw=
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.3 h1:EVqfAKeH5bZB9/MtTIK2+p/RKhsihTme7DBixhWJHuQ=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.3/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4 h1:k0jRFHRIbYBw938zYvsiDf8U0SyKClmko2+86voTZHw=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/go.sum
+++ b/main/go.sum
@@ -23,8 +23,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IKw=
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.2 h1:rmWEAFUyZ7dVSFZdPRlQ26e8Vmf3PRDWJ8CyFuhfF5A=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.2/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.3 h1:EVqfAKeH5bZB9/MtTIK2+p/RKhsihTme7DBixhWJHuQ=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.3/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/go.sum
+++ b/main/go.sum
@@ -23,8 +23,6 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IKw=
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.0 h1:F8skmGjeKxRqJOXjV//1xbVIvBBhQG1r+qmyKnYYcRQ=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.0/go.mod h1:nTqN+niHQNN5XLxMgd5MOD+yW9vBi9trYIj4vBuVi2Y=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/go.sum
+++ b/main/go.sum
@@ -23,6 +23,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IKw=
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.2 h1:rmWEAFUyZ7dVSFZdPRlQ26e8Vmf3PRDWJ8CyFuhfF5A=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.2/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -279,7 +279,7 @@ func (srv *HTTPServer) Serve(ctx context.Context) error {
 		log.Debugf(" - Cert: %s", srv.certFile)
 		log.Debugf(" -  Key: %s", srv.keyFile)
 	}
-	log.Printf("starting HTTP service (TCP address %s)", srv.addr)
+	log.Printf("starting HTTP service")
 
 	var err error
 	if srv.TLS {

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -44,9 +44,9 @@ type HTTPMessage struct {
 }
 
 type HTTPResponse struct {
-	Code    int
-	Headers http.Header
-	Content []byte
+	Code    int         `json:"statusCode"`
+	Headers http.Header `json:"headers"`
+	Content []byte      `json:"content"`
 }
 
 // wrapper for http.Error that additionally logs the error message to std.Output
@@ -217,7 +217,7 @@ func (endpnt *ServerEndpoint) handleRequestOriginalData(w http.ResponseWriter, r
 	endpnt.handleRequest(w, r, false)
 }
 
-func (endpnt *ServerEndpoint) handleOptions(writer http.ResponseWriter, request *http.Request) {
+func (endpnt *ServerEndpoint) handleOptions(w http.ResponseWriter, r *http.Request) {
 	return
 }
 

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -279,7 +279,7 @@ func (srv *HTTPServer) Serve(ctx context.Context) error {
 		log.Debugf(" - Cert: %s", srv.certFile)
 		log.Debugf(" -  Key: %s", srv.keyFile)
 	}
-	log.Printf("starting HTTP service")
+	log.Printf("starting HTTP service (TCP address %s)", srv.addr)
 
 	var err error
 	if srv.TLS {

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -44,9 +44,9 @@ type HTTPMessage struct {
 }
 
 type HTTPResponse struct {
-	Code    int         `json:"statusCode"`
-	Headers http.Header `json:"headers"`
-	Content []byte      `json:"content"`
+	StatusCode int         `json:"statusCode"`
+	Headers    http.Header `json:"headers"`
+	Content    []byte      `json:"content"`
 }
 
 // wrapper for http.Error that additionally logs the error message to std.Output
@@ -150,7 +150,7 @@ func forwardBackendResponse(w http.ResponseWriter, respChan chan HTTPResponse) {
 	for k, v := range resp.Headers {
 		w.Header().Set(k, v[0])
 	}
-	w.WriteHeader(resp.Code)
+	w.WriteHeader(resp.StatusCode)
 	_, err := w.Write(resp.Content)
 	if err != nil {
 		log.Errorf("unable to write response: %s", err)

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -297,7 +297,6 @@ func HTTPErrorResponse(code int, message string) HTTPResponse {
 	if message == "" {
 		message = http.StatusText(code)
 	}
-	log.Error(message)
 	return HTTPResponse{
 		Code:    code,
 		Headers: map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}},

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -45,7 +45,7 @@ type HTTPMessage struct {
 
 type HTTPResponse struct {
 	Code    int
-	Headers map[string][]string
+	Headers http.Header
 	Content []byte
 }
 
@@ -291,15 +291,4 @@ func (srv *HTTPServer) Serve(ctx context.Context) error {
 		return fmt.Errorf("error starting HTTP service: %v", err)
 	}
 	return nil
-}
-
-func HTTPErrorResponse(code int, message string) HTTPResponse {
-	if message == "" {
-		message = http.StatusText(code)
-	}
-	return HTTPResponse{
-		Code:    code,
-		Headers: map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}},
-		Content: []byte(message),
-	}
 }

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -52,7 +52,7 @@ func registerPublicKey(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte, keySer
 	}
 	log.Debugf("%s: certificate: %s", uid.String(), cert)
 
-	code, resp, _, err := post(keyService, cert, map[string]string{
+	resp, err := post(keyService, cert, map[string]string{
 		"content-type":         "application/json",
 		"x-ubirch-hardware-id": uid.String(),
 		"x-ubirch-auth-type":   "ubirch",
@@ -61,12 +61,10 @@ func registerPublicKey(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte, keySer
 	if err != nil {
 		return fmt.Errorf("error sending key registration: %v", err)
 	}
-	if httpFailed(code) {
-		return fmt.Errorf("request to %s failed: (%d) %s", keyService, code, string(resp))
+	if httpFailed(resp.Code) {
+		return fmt.Errorf("request to %s failed: (%d) %q", keyService, resp.Code, resp.Content)
 	}
-
-	log.Debugf("%s: key registration successful: (%d) %s", uid.String(), code, string(resp))
-
+	log.Debugf("%s: key registration successful: (%d) %s", uid.String(), resp.Code, string(resp.Content))
 	return nil
 }
 
@@ -80,16 +78,14 @@ func submitCSR(p *ExtendedProtocol, uid uuid.UUID, subjectCountry string, subjec
 	}
 	log.Debugf("%s: CSR [der]: %s", uid.String(), hex.EncodeToString(csr))
 
-	code, resp, _, err := post(identityService, csr, map[string]string{"Content-Type": "application/octet-stream"})
+	resp, err := post(identityService, csr, map[string]string{"Content-Type": "application/octet-stream"})
 	if err != nil {
 		return fmt.Errorf("error sending CSR: %v", err)
 	}
-	if httpFailed(code) {
-		return fmt.Errorf("request to %s failed: (%d) %s", identityService, code, string(resp))
+	if httpFailed(resp.Code) {
+		return fmt.Errorf("request to %s failed: (%d) %q", identityService, resp.Code, resp.Content)
 	}
-
-	log.Debugf("%s: CSR submitted: (%d) %s", uid.String(), code, string(resp))
-
+	log.Debugf("%s: CSR submitted: (%d) %s", uid.String(), resp.Code, string(resp.Content))
 	return nil
 }
 

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -24,15 +24,21 @@ import (
 )
 
 const (
-	devName      = "dev"
-	devUUID      = "9d3c78ff-22f3-4441-a5d1-85c636d486ff"
-	devPublicKey = "LnU8BkvGcZQPy5gWVUL+PHA0DP9dU61H8DBO8hZvTyI7lXIlG1/oruVMT7gS2nlZDK9QG+ugkRt/zTrdLrAYDA=="
+	devName    = "dev"
+	devUUID    = "9d3c78ff-22f3-4441-a5d1-85c636d486ff"
+	devPubKey  = "LnU8BkvGcZQPy5gWVUL+PHA0DP9dU61H8DBO8hZvTyI7lXIlG1/oruVMT7gS2nlZDK9QG+ugkRt/zTrdLrAYDA=="
+	demoName   = "demo"
+	demoUUID   = "07104235-1892-4020-9042-00003c94b60b"
+	demoPubKey = "xm+iIomBRjR3QdvLJrGE1OBs3bAf8EI49FfgBriRk36n4RUYX+0smrYK8tZkl6Lhrt9lzjiUGrXGijRoVE+UjA=="
+	prodName   = "prod"
+	prodUUID   = "10b2e1a4-56b3-4fff-9ada-cc8c20f93016"
+	prodPubKey = "pJdYoJN0N3QTFMBVjZVQie1hhgumQVTy2kX9I7kXjSyoIl40EOa9MX24SBAABBV7xV2IFi1KWMnC1aLOIvOQjQ=="
 )
 
 func initBackendKeys(p *ExtendedProtocol) error {
-	names := []string{devName}
-	uuids := []string{devUUID}
-	pkeys := []string{devPublicKey}
+	names := []string{devName, demoName, prodName}
+	uuids := []string{devUUID, demoUUID, prodUUID}
+	pkeys := []string{devPubKey, demoPubKey, prodPubKey}
 
 	for i, env := range names {
 		uid, err := uuid.Parse(uuids[i])

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -23,46 +23,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const (
-	devName    = "dev"
-	devUUID    = "9d3c78ff-22f3-4441-a5d1-85c636d486ff"
-	devPubKey  = "LnU8BkvGcZQPy5gWVUL+PHA0DP9dU61H8DBO8hZvTyI7lXIlG1/oruVMT7gS2nlZDK9QG+ugkRt/zTrdLrAYDA=="
-	demoName   = "demo"
-	demoUUID   = "07104235-1892-4020-9042-00003c94b60b"
-	demoPubKey = "xm+iIomBRjR3QdvLJrGE1OBs3bAf8EI49FfgBriRk36n4RUYX+0smrYK8tZkl6Lhrt9lzjiUGrXGijRoVE+UjA=="
-	prodName   = "prod"
-	prodUUID   = "10b2e1a4-56b3-4fff-9ada-cc8c20f93016"
-	prodPubKey = "pJdYoJN0N3QTFMBVjZVQie1hhgumQVTy2kX9I7kXjSyoIl40EOa9MX24SBAABBV7xV2IFi1KWMnC1aLOIvOQjQ=="
-)
-
-type identity struct {
-	Name   string
-	UUID   string
-	PubKey string
-}
-
-func initBackendKeys(p *ExtendedProtocol) error {
-	serverIdentities := []identity{
-		{Name: devName, UUID: devUUID, PubKey: devPubKey},
-		{Name: demoName, UUID: demoUUID, PubKey: demoPubKey},
-		{Name: prodName, UUID: prodUUID, PubKey: prodPubKey},
+func initBackendKey(p *ExtendedProtocol, name string, id identity) error {
+	uid, err := uuid.Parse(id.UUID)
+	if err != nil {
+		return err
 	}
-
-	for _, server := range serverIdentities {
-		uid, err := uuid.Parse(server.UUID)
-		if err != nil {
-			return err
-		}
-		pkey, err := base64.StdEncoding.DecodeString(server.PubKey)
-		if err != nil {
-			return err
-		}
-		err = injectVerificationKey(p, server.Name, uid, pkey)
-		if err != nil {
-			return err
-		}
+	pkey, err := base64.StdEncoding.DecodeString(id.PubKey.ECDSA)
+	if err != nil {
+		return err
 	}
-	return nil
+	return injectVerificationKey(p, name, uid, pkey)
 }
 
 func injectVerificationKey(p *ExtendedProtocol, name string, uid uuid.UUID, pubKey []byte) error {

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -61,10 +61,10 @@ func registerPublicKey(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte, keySer
 	if err != nil {
 		return fmt.Errorf("error sending key registration: %v", err)
 	}
-	if httpFailed(resp.Code) {
-		return fmt.Errorf("request to %s failed: (%d) %q", keyService, resp.Code, resp.Content)
+	if httpFailed(resp.StatusCode) {
+		return fmt.Errorf("request to %s failed: (%d) %q", keyService, resp.StatusCode, resp.Content)
 	}
-	log.Debugf("%s: key registration successful: (%d) %s", uid.String(), resp.Code, string(resp.Content))
+	log.Debugf("%s: key registration successful: (%d) %s", uid.String(), resp.StatusCode, string(resp.Content))
 	return nil
 }
 
@@ -82,10 +82,10 @@ func submitCSR(p *ExtendedProtocol, uid uuid.UUID, subjectCountry string, subjec
 	if err != nil {
 		return fmt.Errorf("error sending CSR: %v", err)
 	}
-	if httpFailed(resp.Code) {
-		return fmt.Errorf("request to %s failed: (%d) %q", identityService, resp.Code, resp.Content)
+	if httpFailed(resp.StatusCode) {
+		return fmt.Errorf("request to %s failed: (%d) %q", identityService, resp.StatusCode, resp.Content)
 	}
-	log.Debugf("%s: CSR submitted: (%d) %s", uid.String(), resp.Code, string(resp.Content))
+	log.Debugf("%s: CSR submitted: (%d) %s", uid.String(), resp.StatusCode, string(resp.Content))
 	return nil
 }
 

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -36,20 +36,31 @@ const (
 )
 
 func initBackendKeys(p *ExtendedProtocol) error {
-	names := []string{devName, demoName, prodName}
-	uuids := []string{devUUID, demoUUID, prodUUID}
-	pkeys := []string{devPubKey, demoPubKey, prodPubKey}
+	identities := map[string]map[string]string{
+		devName: {
+			"UUID":   devUUID,
+			"pubKey": devPubKey,
+		},
+		demoName: {
+			"UUID":   demoUUID,
+			"pubKey": demoPubKey,
+		},
+		prodName: {
+			"UUID":   prodUUID,
+			"pubKey": prodPubKey,
+		},
+	}
 
-	for i, env := range names {
-		uid, err := uuid.Parse(uuids[i])
+	for name, m := range identities {
+		uid, err := uuid.Parse(m["UUID"])
 		if err != nil {
 			return err
 		}
-		pkey, err := base64.StdEncoding.DecodeString(pkeys[i])
+		pkey, err := base64.StdEncoding.DecodeString(m["pubKey"])
 		if err != nil {
 			return err
 		}
-		err = injectVerificationKey(p, env, uid, pkey)
+		err = injectVerificationKey(p, name, uid, pkey)
 		if err != nil {
 			return err
 		}

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -23,20 +23,21 @@ import (
 )
 
 func setPublicKey(p *ExtendedProtocol, name string, id string, pubKey_64 string) error {
+	log.Debugf("setting verification key \"%s\": %s", name, pubKey_64)
+
 	uid, err := uuid.Parse(id)
 	if err != nil {
-		return err
+		return fmt.Errorf("invalid UUID for verification key \"%s\": %v", name, err)
 	}
 
 	pkey, err := base64.StdEncoding.DecodeString(pubKey_64)
 	if err != nil {
-		return err
+		return fmt.Errorf("decoding verification key \"%s\" failed: %v", name, err)
 	}
 
-	log.Debugf("setting verification key \"%s\": %s", name, base64.StdEncoding.EncodeToString(pkey))
 	err = p.SetPublicKey(name, uid, pkey)
 	if err != nil {
-		return err
+		return fmt.Errorf("setting verification key \"%s\" failed: %v", name, err)
 	}
 
 	return p.PersistContext()

--- a/main/main.go
+++ b/main/main.go
@@ -84,7 +84,7 @@ func main() {
 	}
 
 	// insert backend public keys into keystore for verification
-	err = initBackendKeys(&p)
+	err = initBackendKey(&p, conf.Env, conf.ServerIdentity)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -100,7 +100,7 @@ func main() {
 	// set up HTTP server
 	httpServer := HTTPServer{
 		router:   NewRouter(),
-		addr:     conf.TCPaddr,
+		addr:     conf.TCP_addr,
 		TLS:      conf.TLS,
 		certFile: conf.TLS_CertFile,
 		keyFile:  conf.TLS_KeyFile,

--- a/main/main.go
+++ b/main/main.go
@@ -83,6 +83,12 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// insert backend public keys into keystore for verification
+	err = initBackendKeys(&p)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	// create a waitgroup that contains all asynchronous operations
 	// a cancellable context is used to stop the operations gracefully
 	ctx, cancel := context.WithCancel(context.Background())

--- a/main/main.go
+++ b/main/main.go
@@ -100,7 +100,7 @@ func main() {
 	// set up HTTP server
 	httpServer := HTTPServer{
 		router:   NewRouter(),
-		addr:     conf.TCP_addr,
+		addr:     conf.TCPaddr,
 		TLS:      conf.TLS,
 		certFile: conf.TLS_CertFile,
 		keyFile:  conf.TLS_KeyFile,

--- a/main/main.go
+++ b/main/main.go
@@ -83,8 +83,8 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// insert backend public keys into keystore for verification
-	err = initBackendKey(&p, conf.Env, conf.ServerIdentity)
+	// insert backend public key into keystore for verification of server responses
+	err = setPublicKey(&p, conf.Env, conf.ServerIdentity.UUID, conf.ServerIdentity.PubKey.ECDSA)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main/signer.go
+++ b/main/signer.go
@@ -55,17 +55,13 @@ func anchorHash(p *ExtendedProtocol, name string, hash []byte, auth []byte, conf
 
 	// verify backend response signature
 	verified, err := p.Verify(conf.Env, respBody)
-	if err != nil {
-		errMsg := fmt.Sprintf("could not verify backend response signature: %v\n"+
-			" request UPP: %s\n"+
-			" backend response: (%d) %s [%q]",
-			err, hex.EncodeToString(upp), respCode, hex.EncodeToString(respBody), respBody)
-		return HTTPErrorResponse(http.StatusInternalServerError, ""), fmt.Errorf(errMsg)
-	} else if !verified {
+	if !verified {
+		if err != nil {
+			log.Errorf("could not verify backend response signature: %v", err)
+		}
 		errMsg := fmt.Sprintf("backend response signature verification failed\n"+
-			" request UPP: %s\n"+
-			" backend response: (%d) %s [%q]",
-			hex.EncodeToString(upp), respCode, hex.EncodeToString(respBody), respBody)
+			" backend response: (%d) %q [%s]",
+			respCode, respBody, hex.EncodeToString(respBody))
 		return HTTPErrorResponse(http.StatusBadGateway, errMsg), fmt.Errorf(errMsg)
 	}
 	log.Debugf("%s: backend response signature verified", name)
@@ -75,8 +71,8 @@ func anchorHash(p *ExtendedProtocol, name string, hash []byte, auth []byte, conf
 	if err != nil {
 		errMsg := fmt.Sprintf("could not decode backend response: %v\n"+
 			" request UPP: %s\n"+
-			" backend response: (%d) %s [%q]",
-			err, hex.EncodeToString(upp), respCode, hex.EncodeToString(respBody), respBody)
+			" backend response: (%d) %q [%s]",
+			err, hex.EncodeToString(upp), respCode, respBody, hex.EncodeToString(respBody))
 		return HTTPErrorResponse(http.StatusBadGateway, errMsg), fmt.Errorf(errMsg)
 	}
 
@@ -103,10 +99,9 @@ func anchorHash(p *ExtendedProtocol, name string, hash []byte, auth []byte, conf
 			if err != nil {
 				log.Errorf("could not verify backend response chain: %v", err)
 			}
-			errMsg := fmt.Sprintf("backend response chain check failed\n"+
-				" request UPP: %s\n"+
-				" backend response: (%d) %s",
-				hex.EncodeToString(upp), respCode, hex.EncodeToString(respBody))
+			errMsg := "backend response chain check failed\n" +
+				fmt.Sprintf(" request UPP: %s\n", hex.EncodeToString(upp)) +
+				fmt.Sprintf(" backend response: (%d) %s", respCode, hex.EncodeToString(respBody))
 			return HTTPErrorResponse(http.StatusBadGateway, errMsg), fmt.Errorf(errMsg)
 		}
 		log.Debugf("%s: backend response chain verified", name)

--- a/main/signer.go
+++ b/main/signer.go
@@ -91,9 +91,9 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 							http.StatusBadGateway,
 							fmt.Sprintf("%s: backend response not chained to sent UPP: previous signature does not match signature of request UPP\n"+
 								" backend response was: (%d) %s", name, respCode, base64.StdEncoding.EncodeToString(respBody)))
-					} else {
-						log.Debugf("%s: backend response chain verified", name)
+						continue
 					}
+					log.Debugf("%s: backend response chain verified", name)
 				}
 
 				// get request ID from backend response payload
@@ -120,6 +120,7 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 						http.StatusBadGateway,
 						fmt.Sprintf("backend responded with success status code but response is not verifiable\n"+
 							" backend response was: (%d) %s", respCode, base64.StdEncoding.EncodeToString(respBody)))
+					continue
 				}
 
 				log.Debugf("%s: UPP successfully sent to %s", name, conf.Niomon)

--- a/main/signer.go
+++ b/main/signer.go
@@ -65,7 +65,8 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 				err = p.PersistContext()
 				if err != nil {
 					msg.Response <- errorResponse(http.StatusInternalServerError, "")
-					return fmt.Errorf("unable to persist last signature for UUID %s: %v", name, err)
+					return fmt.Errorf("unable to persist last signature: %v [\"%s\": \"%s\"]",
+						err, name, base64.StdEncoding.EncodeToString(p.Signatures[msg.ID]))
 				}
 			}
 			msg.Response <- resp
@@ -103,7 +104,7 @@ func handleSigningRequest(p *ExtendedProtocol, name string, hash []byte, auth []
 	// check if request was successful
 	var httpFailedError error
 	if httpFailed(backendResp.Code) {
-		httpFailedError = fmt.Errorf("request to UBIRCH Authentication Service (%s) failed", serviceURL)
+		httpFailedError = fmt.Errorf("request to UBIRCH Authentication Service (%s) was unsuccessful", serviceURL)
 	}
 
 	return extendedResponse(backendResp, hash, upp, requestID), httpFailedError

--- a/main/signer.go
+++ b/main/signer.go
@@ -99,9 +99,11 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 				}
 
 				// verify chain
-				if !bytes.Equal(respUPP.GetPrevSignature(), p.Signatures[uid]) {
-					log.Errorf("backend response not chained to sent UPP: previous signature does not match signature of request UPP")
-					// todo handle signature mismatch
+				if !bytes.Equal(p.Signatures[uid], respUPP.GetPrevSignature()) {
+					msg.Response <- HTTPErrorResponse(
+						http.StatusBadGateway,
+						fmt.Sprintf("backend response not chained to sent UPP: previous signature does not match signature of request UPP\n"+
+							" backend response was: (%d) %s", respCode, base64.StdEncoding.EncodeToString(respBody)))
 				}
 			}
 

--- a/main/signer.go
+++ b/main/signer.go
@@ -74,7 +74,7 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 				// TODO verify backend response signature
 
 				// verify that backend response previous signature matches signature of request UPP
-				_, isRespChainedUPP = respUPP.(*ubirch.ChainedUPP)
+				isRespChainedUPP = respUPP.GetVersion() == ubirch.Chained
 				if isRespChainedUPP {
 					if !bytes.Equal(p.Signatures[uid], respUPP.GetPrevSignature()) {
 						msg.Response <- HTTPErrorResponse(

--- a/main/signer.go
+++ b/main/signer.go
@@ -104,7 +104,7 @@ func handleSigningRequest(p *ExtendedProtocol, name string, hash []byte, auth []
 	// check if request was successful
 	var httpFailedError error
 	if httpFailed(backendResp.Code) {
-		httpFailedError = fmt.Errorf("request to UBIRCH Authentication Service (%s) was unsuccessful", serviceURL)
+		httpFailedError = fmt.Errorf("request to UBIRCH Authentication Service failed with response status code: %d", backendResp.Code)
 	}
 
 	return extendedResponse(hash, requestUPP, backendResp, requestID), httpFailedError
@@ -126,7 +126,7 @@ func anchorHash(p *ExtendedProtocol, name string, hash []byte, auth []byte) (ubi
 	// send UPP to ubirch backend
 	resp, err := post(serviceURL, uppBytes, niomonHeaders(name, auth))
 	if err != nil {
-		return nil, HTTPResponse{}, fmt.Errorf("could not send request to UBIRCH Authentication Service: %v", err)
+		return nil, HTTPResponse{}, fmt.Errorf("sending request to UBIRCH Authentication Service failed: %v", err)
 	}
 	log.Debugf("%s: backend response: (%d) %s", name, resp.Code, hex.EncodeToString(resp.Content))
 

--- a/main/signer.go
+++ b/main/signer.go
@@ -112,11 +112,11 @@ func anchorHash(p *ExtendedProtocol, name string, hash []byte, auth []byte, conf
 		log.Debugf("%s: backend response chain verified", name)
 	}
 
-	response, err := json.Marshal(map[string][]byte{
-		"hash":      hash,
-		"upp":       upp,
-		"requestID": requestID[:],
-		"response":  respBody,
+	response, err := json.Marshal(map[string]string{
+		"hash":      base64.StdEncoding.EncodeToString(hash),
+		"upp":       hex.EncodeToString(upp),
+		"requestID": requestID.String(),
+		"response":  hex.EncodeToString(respBody),
 	})
 	if err != nil {
 		log.Warnf("error serializing extended response: %v", err)

--- a/main/signer.go
+++ b/main/signer.go
@@ -55,6 +55,7 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 			}
 
 			resp, err := handleSigningRequest(p, name, msg.Hash[:], msg.Auth)
+			msg.Response <- resp
 			if err != nil {
 				log.Errorf("%s: %v", name, err)
 
@@ -69,7 +70,6 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 						err, name, base64.StdEncoding.EncodeToString(p.Signatures[msg.ID]))
 				}
 			}
-			msg.Response <- resp
 
 		case <-ctx.Done():
 			log.Println("finishing signer")

--- a/main/signer.go
+++ b/main/signer.go
@@ -59,30 +59,16 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 			}
 			log.Debugf("%s: response: (%d) %s", name, respCode, hex.EncodeToString(respBody))
 
-			// decode the backend response and verify its validity
-			var isRespDecodable bool
-			var isRespChainedUPP bool
 			var requestID uuid.UUID
 
+			// decode the backend response
 			respUPP, err := ubirch.Decode(respBody)
 			if err != nil {
 				log.Warnf("unable to decode backend response: %v\n backend response was: (%d) %q",
 					err, respCode, respBody)
 			} else {
-				isRespDecodable = true
 
-				// TODO verify backend response signature
-
-				// verify that backend response previous signature matches signature of request UPP
-				isRespChainedUPP = respUPP.GetVersion() == ubirch.Chained
-				if isRespChainedUPP {
-					if !bytes.Equal(p.Signatures[uid], respUPP.GetPrevSignature()) {
-						msg.Response <- HTTPErrorResponse(
-							http.StatusBadGateway,
-							fmt.Sprintf("backend response not chained to sent UPP: previous signature does not match signature of request UPP\n"+
-								" backend response was: (%d) %s", respCode, base64.StdEncoding.EncodeToString(respBody)))
-					}
-				}
+				// todo verify backend response signature
 
 				// get request ID from backend response payload
 				requestID, err = uuid.FromBytes(respUPP.GetPayload()[:16])
@@ -92,7 +78,7 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 				}
 			}
 
-			// check if request was successful
+			// check if sending was successful
 			if httpFailed(respCode) {
 				log.Errorf("%s: sending UPP to %s failed: (%d) %q", name, conf.Niomon, respCode, respBody)
 
@@ -102,16 +88,8 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, "")
 					return fmt.Errorf("unable to load last signature for UUID %s: %v", name, err)
 				}
-			} else {
-				if !isRespDecodable || !isRespChainedUPP {
-					msg.Response <- HTTPErrorResponse(
-						http.StatusBadGateway,
-						fmt.Sprintf("backend responded with success status code but response is not verifiable\n"+
-							" backend response was: (%d) %s", respCode, base64.StdEncoding.EncodeToString(respBody)))
-				}
-
+			} else { // success
 				log.Infof("%s: UPP sent to %s (request ID: %s)", name, conf.Niomon, requestID)
-
 
 				// save last signature after UPP was successfully received in ubirch backend
 				err = p.PersistContext()
@@ -119,9 +97,11 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, "")
 					return fmt.Errorf("unable to persist last signature for UUID %s: %v", name, err)
 				}
-				if err != nil {
-					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, "")
-					return fmt.Errorf("unable to persist last signature for UUID %s: %v", name, err)
+
+				// verify chain
+				if !bytes.Equal(respUPP.GetPrevSignature(), p.Signatures[uid]) {
+					log.Errorf("backend response not chained to sent UPP: previous signature does not match signature of request UPP")
+					// todo handle signature mismatch
 				}
 			}
 

--- a/main/signer.go
+++ b/main/signer.go
@@ -99,9 +99,10 @@ func anchorHash(p *ExtendedProtocol, name string, hash []byte, auth []byte, conf
 			if err != nil {
 				log.Errorf("could not verify backend response chain: %v", err)
 			}
-			errMsg := "backend response chain check failed\n" +
-				fmt.Sprintf(" request UPP: %s\n", hex.EncodeToString(upp)) +
-				fmt.Sprintf(" backend response: (%d) %s", respCode, hex.EncodeToString(respBody))
+			errMsg := fmt.Sprintf("backend response chain check failed\n"+
+				" request UPP: %s\n"+
+				" backend response: (%d) %s",
+				hex.EncodeToString(upp), respCode, hex.EncodeToString(respBody))
 			return HTTPErrorResponse(http.StatusBadGateway, errMsg), fmt.Errorf(errMsg)
 		}
 		log.Debugf("%s: backend response chain verified", name)

--- a/main/signer.go
+++ b/main/signer.go
@@ -82,19 +82,19 @@ func handleSigningRequest(p *ExtendedProtocol, name string, hash []byte, auth []
 	log.Infof("%s: hash: %s", name, base64.StdEncoding.EncodeToString(hash))
 
 	// send a UPP containing the hash to UBIRCH authentication service
-	requestUPP, backendResp, err := anchorHash(p, name, hash, auth)
+	requestUPPStruct, backendResp, err := anchorHash(p, name, hash, auth)
 	if err != nil {
 		return errorResponse(http.StatusInternalServerError, ""), err
 	}
 
 	// verify validity of the backend response
-	responseUPP, err := verifyBackendResponse(p, requestUPP, backendResp)
+	responseUPPStruct, err := verifyBackendResponse(p, requestUPPStruct, backendResp)
 	if err != nil {
 		return errorResponse(http.StatusBadGateway, err.Error()), err
 	}
 
 	// get request ID from backend response
-	requestID, err := getRequestID(responseUPP)
+	requestID, err := getRequestID(responseUPPStruct)
 	if err != nil {
 		log.Errorf("could not get request ID from backend response: %v", err)
 	} else {
@@ -107,7 +107,7 @@ func handleSigningRequest(p *ExtendedProtocol, name string, hash []byte, auth []
 		httpFailedError = fmt.Errorf("request to UBIRCH Authentication Service failed with response status code: %d", backendResp.Code)
 	}
 
-	return extendedResponse(hash, requestUPP, backendResp, requestID), httpFailedError
+	return extendedResponse(hash, requestUPPStruct, backendResp, requestID), httpFailedError
 }
 
 func anchorHash(p *ExtendedProtocol, name string, hash []byte, auth []byte) (ubirch.UPP, HTTPResponse, error) {
@@ -118,7 +118,7 @@ func anchorHash(p *ExtendedProtocol, name string, hash []byte, auth []byte) (ubi
 	}
 	log.Debugf("%s: UPP: %s", name, hex.EncodeToString(uppBytes))
 
-	upp, err := ubirch.Decode(uppBytes)
+	uppStruct, err := ubirch.Decode(uppBytes)
 	if err != nil {
 		return nil, HTTPResponse{}, fmt.Errorf("could not decode created UBIRCH Protocol Package: %v", err)
 	}
@@ -130,7 +130,7 @@ func anchorHash(p *ExtendedProtocol, name string, hash []byte, auth []byte) (ubi
 	}
 	log.Debugf("%s: backend response: (%d) %s", name, resp.Code, hex.EncodeToString(resp.Content))
 
-	return upp, resp, nil
+	return uppStruct, resp, nil
 }
 
 func niomonHeaders(name string, auth []byte) map[string]string {
@@ -141,8 +141,8 @@ func niomonHeaders(name string, auth []byte) map[string]string {
 	}
 }
 
-func verifyBackendResponse(p *ExtendedProtocol, requUPP ubirch.UPP, backendResp HTTPResponse) (ubirch.UPP, error) {
-	// check if backend response can be a UPP
+func verifyBackendResponse(p *ExtendedProtocol, requUPPStruct ubirch.UPP, backendResp HTTPResponse) (ubirch.UPP, error) {
+	// check if backend response is a UPP or something else, like an error message string, for example "Timeout"
 	if !hasUPPHeaders(backendResp.Content) {
 		return nil, fmt.Errorf("invalid backend response: (%d) %q", backendResp.Code, backendResp.Content)
 	}
@@ -156,7 +156,7 @@ func verifyBackendResponse(p *ExtendedProtocol, requUPP ubirch.UPP, backendResp 
 	}
 
 	// decode the backend response UPP
-	respUPP, err := ubirch.Decode(backendResp.Content)
+	respUPPStruct, err := ubirch.Decode(backendResp.Content)
 	if err != nil {
 		log.Errorf("decoding backend response failed: %v", err)
 		return nil, fmt.Errorf("invalid backend response UPP")
@@ -164,7 +164,7 @@ func verifyBackendResponse(p *ExtendedProtocol, requUPP ubirch.UPP, backendResp 
 
 	// verify that backend response previous signature matches signature of request UPP
 	if httpSuccess(backendResp.Code) {
-		if chainOK, err := ubirch.CheckChainLink(requUPP, respUPP); !chainOK {
+		if chainOK, err := ubirch.CheckChainLink(requUPPStruct, respUPPStruct); !chainOK {
 			if err != nil {
 				log.Errorf("could not verify backend response chain: %v", err)
 			}
@@ -172,7 +172,7 @@ func verifyBackendResponse(p *ExtendedProtocol, requUPP ubirch.UPP, backendResp 
 		}
 	}
 
-	return respUPP, nil
+	return respUPPStruct, nil
 }
 
 func hasUPPHeaders(data []byte) bool {
@@ -198,8 +198,8 @@ func errorResponse(code int, message string) HTTPResponse {
 	}
 }
 
-func extendedResponse(hash []byte, upp ubirch.UPP, resp HTTPResponse, requestID uuid.UUID) HTTPResponse {
-	uppBytes, _ := ubirch.Encode(upp)
+func extendedResponse(hash []byte, uppStruct ubirch.UPP, resp HTTPResponse, requestID uuid.UUID) HTTPResponse {
+	uppBytes, _ := ubirch.Encode(uppStruct)
 	extendedResp, err := json.Marshal(map[string]string{
 		"hash":      base64.StdEncoding.EncodeToString(hash),
 		"upp":       base64.StdEncoding.EncodeToString(uppBytes),

--- a/main/signer.go
+++ b/main/signer.go
@@ -112,8 +112,13 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 
 				log.Infof("%s: UPP sent to %s (request ID: %s)", name, conf.Niomon, requestID)
 
+
 				// save last signature after UPP was successfully received in ubirch backend
 				err = p.PersistContext()
+				if err != nil {
+					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, "")
+					return fmt.Errorf("unable to persist last signature for UUID %s: %v", name, err)
+				}
 				if err != nil {
 					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, "")
 					return fmt.Errorf("unable to persist last signature for UUID %s: %v", name, err)

--- a/main/signer.go
+++ b/main/signer.go
@@ -200,8 +200,8 @@ func errorResponse(code int, message string) HTTPResponse {
 func extendedResponse(resp HTTPResponse, hash []byte, upp []byte, requestID uuid.UUID) HTTPResponse {
 	extendedResp, err := json.Marshal(map[string]string{
 		"hash":      base64.StdEncoding.EncodeToString(hash),
-		"upp":       hex.EncodeToString(upp),
-		"response":  hex.EncodeToString(resp.Content),
+		"upp":       base64.StdEncoding.EncodeToString(upp),
+		"response":  base64.StdEncoding.EncodeToString(resp.Content),
 		"requestID": requestID.String(),
 	})
 	if err != nil {

--- a/main/signer.go
+++ b/main/signer.go
@@ -100,7 +100,7 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 
 				// verify chain
 				if !bytes.Equal(respUPP.GetPrevSignature(), p.Signatures[uid]) {
-					log.Errorf("backend response not chained to sent UPP: previous signature does not match signature of sent UPP")
+					log.Errorf("backend response not chained to sent UPP: previous signature does not match signature of request UPP")
 					// todo handle signature mismatch
 				}
 			}

--- a/main/signer.go
+++ b/main/signer.go
@@ -59,16 +59,30 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 			}
 			log.Debugf("%s: response: (%d) %s", name, respCode, hex.EncodeToString(respBody))
 
+			// decode the backend response and verify its validity
+			var isRespDecodable bool
+			var isRespChainedUPP bool
 			var requestID uuid.UUID
 
-			// decode the backend response
 			respUPP, err := ubirch.Decode(respBody)
 			if err != nil {
 				log.Warnf("unable to decode backend response: %v\n backend response was: (%d) %q",
 					err, respCode, respBody)
 			} else {
+				isRespDecodable = true
 
-				// todo verify backend response signature
+				// TODO verify backend response signature
+
+				// verify that backend response previous signature matches signature of request UPP
+				_, isRespChainedUPP = respUPP.(*ubirch.ChainedUPP)
+				if isRespChainedUPP {
+					if !bytes.Equal(p.Signatures[uid], respUPP.GetPrevSignature()) {
+						msg.Response <- HTTPErrorResponse(
+							http.StatusBadGateway,
+							fmt.Sprintf("backend response not chained to sent UPP: previous signature does not match signature of request UPP\n"+
+								" backend response was: (%d) %s", respCode, base64.StdEncoding.EncodeToString(respBody)))
+					}
+				}
 
 				// get request ID from backend response payload
 				requestID, err = uuid.FromBytes(respUPP.GetPayload()[:16])
@@ -78,7 +92,7 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 				}
 			}
 
-			// check if sending was successful
+			// check if request was successful
 			if httpFailed(respCode) {
 				log.Errorf("%s: sending UPP to %s failed: (%d) %q", name, conf.Niomon, respCode, respBody)
 
@@ -88,7 +102,14 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, "")
 					return fmt.Errorf("unable to load last signature for UUID %s: %v", name, err)
 				}
-			} else { // success
+			} else {
+				if !isRespDecodable || !isRespChainedUPP {
+					msg.Response <- HTTPErrorResponse(
+						http.StatusBadGateway,
+						fmt.Sprintf("backend responded with success status code but response is not verifiable\n"+
+							" backend response was: (%d) %s", respCode, base64.StdEncoding.EncodeToString(respBody)))
+				}
+
 				log.Infof("%s: UPP sent to %s (request ID: %s)", name, conf.Niomon, requestID)
 
 				// save last signature after UPP was successfully received in ubirch backend
@@ -96,14 +117,6 @@ func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtoco
 				if err != nil {
 					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, "")
 					return fmt.Errorf("unable to persist last signature for UUID %s: %v", name, err)
-				}
-
-				// verify chain
-				if !bytes.Equal(p.Signatures[uid], respUPP.GetPrevSignature()) {
-					msg.Response <- HTTPErrorResponse(
-						http.StatusBadGateway,
-						fmt.Sprintf("backend response not chained to sent UPP: previous signature does not match signature of request UPP\n"+
-							" backend response was: (%d) %s", respCode, base64.StdEncoding.EncodeToString(respBody)))
 				}
 			}
 

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -32,16 +33,74 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var (
+	verifyServiceURL              string
+	keyServiceURL                 string
+	verifyFromKnownIdentitiesOnly bool
+)
+
 type verification struct {
 	UPP     []byte `json:"upp"`
 	Prev    []byte `json:"prev"`
 	Anchors []byte `json:"anchors"`
 }
 
+type verificationResponse struct {
+	Error  string `json:"error,omitempty"`
+	Hash   []byte `json:"hash,omitempty"`
+	UPP    []byte `json:"upp,omitempty"`
+	UUID   string `json:"uuid,omitempty"`
+	PubKey []byte `json:"pubKey,omitempty"`
+}
+
+// verifier retrieves corresponding UPP for a given hash from the ubirch backend and verifies the validity of its signature
+func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtocol, conf Config) error {
+	verifyServiceURL = conf.VerifyService
+	keyServiceURL = conf.KeyService
+	verifyFromKnownIdentitiesOnly = true // todo add to config
+
+	for {
+		select {
+		case msg := <-msgHandler:
+
+			resp := handleVerificationRequest(p, msg.Hash[:])
+			msg.Response <- resp
+			if httpFailed(resp.Code) {
+				log.Errorf("%s", string(resp.Content))
+			}
+
+		case <-ctx.Done():
+			log.Println("finishing verifier")
+			return nil
+		}
+	}
+}
+
+func handleVerificationRequest(p *ExtendedProtocol, hash []byte) HTTPResponse {
+	log.Infof("verifying hash %s", base64.StdEncoding.EncodeToString(hash))
+
+	// retrieve certificate for hash from the ubirch backend
+	code, upp, err := loadUPP(hash)
+	if err != nil {
+		return errorResponse(code, err.Error())
+	}
+	log.Debugf("retrieved UPP %s", hex.EncodeToString(upp))
+
+	// verify validity of the retrieved UPP locally
+	name, pkey, err := verifyUPP(p, upp)
+	if err != nil {
+		return getVerificationResponse(http.StatusUnprocessableEntity, hash, upp, name, pkey, err.Error())
+	}
+	log.Debugf("verified UPP from identity %s using public key %s", name, base64.StdEncoding.EncodeToString(pkey))
+
+	return getVerificationResponse(http.StatusOK, hash, upp, name, pkey, "")
+}
+
 // loadUPP retrieves the UPP which contains a given hash from the ubirch backend
-func loadUPP(hashString string, verifyService string) ([]byte, int, error) {
+func loadUPP(hash []byte) (int, []byte, error) {
 	var resp *http.Response
 	var err error
+	hashBase64String := base64.StdEncoding.EncodeToString(hash)
 
 	n := 0
 	for stay, timeout := true, time.After(5*time.Second); stay; {
@@ -50,14 +109,14 @@ func loadUPP(hashString string, verifyService string) ([]byte, int, error) {
 		case <-timeout:
 			stay = false
 		default:
-			resp, err = http.Post(verifyService, "text/plain", strings.NewReader(hashString))
+			resp, err = http.Post(verifyServiceURL, "text/plain", strings.NewReader(hashBase64String))
 			if err != nil {
-				return nil, http.StatusInternalServerError, fmt.Errorf("error sending verification request: %v", err)
+				return http.StatusInternalServerError, nil, fmt.Errorf("error sending verification request: %v", err)
 			}
 			stay = httpFailed(resp.StatusCode)
 			if stay {
 				_ = resp.Body.Close()
-				log.Printf("Couldn't verify hash yet (%d). Retry... %d", resp.StatusCode, n)
+				log.Debugf("Couldn't verify hash yet (%d). Retry... %d", resp.StatusCode, n)
 				time.Sleep(time.Second)
 			}
 		}
@@ -66,119 +125,106 @@ func loadUPP(hashString string, verifyService string) ([]byte, int, error) {
 	defer resp.Body.Close()
 
 	if httpFailed(resp.StatusCode) {
-		return nil, resp.StatusCode, fmt.Errorf("could not (yet) retrieve certificate for hash %s from verification service (%s): %s", hashString, verifyService, resp.Status)
+		respBodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Warnf("unable to decode verification response: %v", err)
+		}
+		return resp.StatusCode, nil, fmt.Errorf("could not retrieve certificate for hash %s from UBIRCH verification service (%s): - %s - %q", hashBase64String, verifyServiceURL, resp.Status, respBodyBytes)
 	}
 
 	vf := verification{}
 	err = json.NewDecoder(resp.Body).Decode(&vf)
 	if err != nil {
-		return nil, http.StatusInternalServerError, fmt.Errorf("unable to decode verification response: %v", err)
+		return http.StatusBadGateway, nil, fmt.Errorf("unable to decode verification response: %v", err)
 	}
-	return vf.UPP, resp.StatusCode, nil
+	return resp.StatusCode, vf.UPP, nil
 }
 
-// verifyUPP verifies the validity of a UPP's signature. Requests public key from the key service if unknown.
-func verifyUPP(p *ExtendedProtocol, upp []byte, keyService string) (uuid.UUID, error) {
-	o, err := ubirch.DecodeChained(upp)
+// verifyUPP verifies the signature of UPPs from known identities using their public keys from the local keystore
+func verifyUPP(p *ExtendedProtocol, upp []byte) (string, []byte, error) {
+	uppStruct, err := ubirch.Decode(upp)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("UPP decoding failed: %v", err)
+		return "", nil, fmt.Errorf("retrieved invalid UPP: %v", err)
 	}
-	id := o.Uuid
+
+	id := uppStruct.GetUuid()
 	name := id.String()
 
-	pubkey, err := loadPublicKey(p, name, id, keyService)
+	pubkey, err := p.GetPublicKey(name)
 	if err != nil {
-		return id, err
+		if verifyFromKnownIdentitiesOnly {
+			return name, nil, fmt.Errorf("retrieved certificate for requested hash is from unknown identity")
+		} else {
+			log.Warnf("couldn't get public key for identity %s from local context", name)
+			pubkey, err = loadPublicKey(p, name, id)
+			if err != nil {
+				return name, nil, err
+			}
+		}
 	}
-	log.Debugf("verifying validity of UPP signature using pubkey %s of identity %s", base64.StdEncoding.EncodeToString(pubkey), name)
 
 	verified, err := p.Verify(name, upp)
-	if err != nil {
-		return id, err
-	}
 	if !verified {
-		return id, fmt.Errorf("validity of UPP signature could not be verified using public key %s of identity %s", base64.StdEncoding.EncodeToString(pubkey), name)
+		if err != nil {
+			log.Error(err)
+		}
+		return name, pubkey, fmt.Errorf("signature of retrieved certificate for requested hash could not be verified")
 	}
-	return id, nil
+
+	return name, pubkey, nil
 }
 
 // loadPublicKey retrieves the first valid public key associated with an identity from the key service
-func loadPublicKey(p *ExtendedProtocol, name string, id uuid.UUID, keyService string) ([]byte, error) {
-	pubkey, err := p.GetPublicKey(name)
+func loadPublicKey(p *ExtendedProtocol, name string, id uuid.UUID) ([]byte, error) {
+	log.Debugf("requesting public key for identity %s from key service (%s)", id.String(), keyServiceURL)
+
+	keys, err := requestPublicKeys(keyServiceURL, id)
 	if err != nil {
-		log.Warnf("couldn't get public key for identity %s from local context", name)
-		log.Printf("requesting public key for identity %s from key service: %s", id.String(), keyService)
-
-		keys, err := requestPublicKeys(keyService, id)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(keys) < 1 {
-			return nil, fmt.Errorf("no public key for identity %s registered at key service (%s)", id.String(), keyService)
-		} else if len(keys) > 1 {
-			log.Warnf("several public keys registered for identity %s", id.String())
-		}
-
-		log.Printf("retrieved public key for identity %s: %s", keys[0].PubKeyInfo.HwDeviceId, keys[0].PubKeyInfo.PubKey)
-
-		pubkey, err = base64.StdEncoding.DecodeString(keys[0].PubKeyInfo.PubKey)
-		if err != nil {
-			return nil, fmt.Errorf("public key not in base64 encoding: %v", err)
-		}
-
-		err = p.SetPublicKey(name, id, pubkey)
-		if err != nil {
-			return nil, fmt.Errorf("unable to set public key in protocol context: %v", err)
-		}
-
-		// persist new public key
-		err = p.PersistContext()
-		if err != nil {
-			log.Errorf("unable to persist retrieved public key for UUID %s: %v", name, err)
-		}
+		return nil, err
 	}
+
+	if len(keys) < 1 {
+		return nil, fmt.Errorf("no public key for identity %s registered at key service (%s)", id.String(), keyServiceURL)
+	} else if len(keys) > 1 {
+		log.Warnf("several public keys registered for identity %s", id.String())
+	}
+
+	log.Printf("retrieved public key for identity %s: %s", keys[0].PubKeyInfo.HwDeviceId, keys[0].PubKeyInfo.PubKey)
+
+	pubkey, err := base64.StdEncoding.DecodeString(keys[0].PubKeyInfo.PubKey)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding retrieved public key: %v", err)
+	}
+
+	// inject new public key into protocol context for verification
+	err = p.SetPublicKey(name, id, pubkey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to set retrieved public key for verification: %v", err)
+	}
+
+	err = p.PersistContext()
+	if err != nil {
+		log.Errorf("unable to persist retrieved public key for UUID %s: %v", name, err)
+	}
+
 	return pubkey, nil
 }
 
-// verifier retrieves corresponding UPP for a given hash from the ubirch backend and verifies the validity of its signature
-func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtocol, conf Config) error {
-	for {
-		select {
-		case msg := <-msgHandler:
+func getVerificationResponse(respCode int, hash []byte, upp []byte, name string, pkey []byte, errMsg string) HTTPResponse {
+	verificationResp, err := json.Marshal(verificationResponse{
+		Hash:   hash,
+		UPP:    upp,
+		UUID:   name,
+		PubKey: pkey,
+		Error:  errMsg,
+	})
+	if err != nil {
+		log.Warnf("error serializing response: %v", err)
+	}
 
-			hash64 := base64.StdEncoding.EncodeToString(msg.Hash[:])
-			log.Printf("%s: verifying", hash64)
-
-			// retrieve corresponding UPP from the ubirch backend
-			upp, code, err := loadUPP(hash64, conf.VerifyService)
-			if err != nil {
-				msg.Response <- errorResponse(code, fmt.Sprintf("verification of hash %s failed! %v", hash64, err))
-				continue
-			}
-
-			upp64 := base64.StdEncoding.EncodeToString(upp)
-			log.Debugf("%s: retrieved UPP: %s", hash64, hex.EncodeToString(upp))
-
-			// verify validity of the retrieved UPP locally
-			uid, err := verifyUPP(p, upp, conf.KeyService)
-			if err != nil {
-				msg.Response <- errorResponse(http.StatusInternalServerError, fmt.Sprintf("verification of UPP %s failed! %v", upp64, err))
-				continue
-			}
-
-			headers := map[string][]string{"Content-Type": {"application/json"}}
-			response, err := json.Marshal(map[string]string{"uuid": uid.String(), "hash": hash64, "upp": upp64})
-			if err != nil {
-				log.Warnf("error serializing extended response: %s", err)
-				headers = map[string][]string{"Content-Type": {"application/octet-stream"}}
-				response = upp
-			}
-			msg.Response <- HTTPResponse{Code: code, Headers: headers, Content: response}
-
-		case <-ctx.Done():
-			log.Println("finishing verifier")
-			return nil
-		}
+	return HTTPResponse{
+		Code:    respCode,
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Content: verificationResp,
 	}
 }

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -157,18 +157,18 @@ func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProto
 				continue
 			}
 
-			upp64 := base64.StdEncoding.EncodeToString(upp)
-			log.Debugf("%s: retrieved UPP: %s", hash64, hex.EncodeToString(upp))
+			upp_hex := hex.EncodeToString(upp)
+			log.Debugf("%s: retrieved UPP: %s", hash64, upp_hex)
 
 			// verify validity of the retrieved UPP locally
 			uid, err := verifyUPP(p, upp, conf.KeyService)
 			if err != nil {
-				msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, fmt.Sprintf("verification of UPP %s failed! %v", upp64, err))
+				msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, fmt.Sprintf("verification of UPP %s failed! %v", upp_hex, err))
 				continue
 			}
 
 			headers := map[string][]string{"Content-Type": {"application/json"}}
-			response, err := json.Marshal(map[string]string{"uuid": uid.String(), "hash": hash64, "upp": upp64})
+			response, err := json.Marshal(map[string]string{"uuid": uid.String(), "hash": hash64, "upp": upp_hex})
 			if err != nil {
 				log.Warnf("error serializing extended response: %s", err)
 				headers = map[string][]string{"Content-Type": {"application/octet-stream"}}

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -157,18 +157,18 @@ func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProto
 				continue
 			}
 
-			upp_hex := hex.EncodeToString(upp)
-			log.Debugf("%s: retrieved UPP: %s", hash64, upp_hex)
+			upp64 := base64.StdEncoding.EncodeToString(upp)
+			log.Debugf("%s: retrieved UPP: %s", hash64, hex.EncodeToString(upp))
 
 			// verify validity of the retrieved UPP locally
 			uid, err := verifyUPP(p, upp, conf.KeyService)
 			if err != nil {
-				msg.Response <- errorResponse(http.StatusInternalServerError, fmt.Sprintf("verification of UPP %s failed! %v", upp_hex, err))
+				msg.Response <- errorResponse(http.StatusInternalServerError, fmt.Sprintf("verification of UPP %s failed! %v", upp64, err))
 				continue
 			}
 
 			headers := map[string][]string{"Content-Type": {"application/json"}}
-			response, err := json.Marshal(map[string]string{"uuid": uid.String(), "hash": hash64, "upp": upp_hex})
+			response, err := json.Marshal(map[string]string{"uuid": uid.String(), "hash": hash64, "upp": upp64})
 			if err != nil {
 				log.Warnf("error serializing extended response: %s", err)
 				headers = map[string][]string{"Content-Type": {"application/octet-stream"}}

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -92,7 +92,7 @@ func verifyUPP(p *ExtendedProtocol, upp []byte, keyService string) (uuid.UUID, e
 	}
 	log.Debugf("verifying validity of UPP signature using pubkey %s of identity %s", base64.StdEncoding.EncodeToString(pubkey), name)
 
-	verified, err := p.Verify(name, upp, ubirch.Chained)
+	verified, err := p.Verify(name, upp)
 	if err != nil {
 		return id, err
 	}

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -153,7 +153,7 @@ func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProto
 			// retrieve corresponding UPP from the ubirch backend
 			upp, code, err := loadUPP(hash64, conf.VerifyService)
 			if err != nil {
-				msg.Response <- HTTPErrorResponse(code, fmt.Sprintf("verification of hash %s failed! %v", hash64, err))
+				msg.Response <- errorResponse(code, fmt.Sprintf("verification of hash %s failed! %v", hash64, err))
 				continue
 			}
 
@@ -163,7 +163,7 @@ func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProto
 			// verify validity of the retrieved UPP locally
 			uid, err := verifyUPP(p, upp, conf.KeyService)
 			if err != nil {
-				msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, fmt.Sprintf("verification of UPP %s failed! %v", upp_hex, err))
+				msg.Response <- errorResponse(http.StatusInternalServerError, fmt.Sprintf("verification of UPP %s failed! %v", upp_hex, err))
 				continue
 			}
 

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -65,7 +65,7 @@ func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProto
 
 			resp := handleVerificationRequest(p, msg.Hash[:])
 			msg.Response <- resp
-			if httpFailed(resp.Code) {
+			if httpFailed(resp.StatusCode) {
 				log.Errorf("%s", string(resp.Content))
 			}
 
@@ -223,8 +223,8 @@ func getVerificationResponse(respCode int, hash []byte, upp []byte, name string,
 	}
 
 	return HTTPResponse{
-		Code:    respCode,
-		Headers: http.Header{"Content-Type": {"application/json"}},
-		Content: verificationResp,
+		StatusCode: respCode,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Content:    verificationResp,
 	}
 }

--- a/simulation/bombard.py
+++ b/simulation/bombard.py
@@ -105,7 +105,7 @@ def check_signing_response(r: requests.Response, request_type: str, msg: dict, s
 
     if r.status_code != 200:
         print("signing request failed: {} ".format(r.status_code))
-        print("requestID: {}".format(r_map["requestID"]))
+        print("requestID: {}\n".format(r_map["requestID"]))
         return False
     else:
         if r_map["hash"] != hash_64:

--- a/simulation/bombard.py
+++ b/simulation/bombard.py
@@ -3,7 +3,7 @@ import json
 import random
 import sys
 import time
-from binascii import a2b_base64, b2a_base64, unhexlify
+from binascii import a2b_base64, b2a_base64
 
 import msgpack
 import requests
@@ -116,7 +116,7 @@ def check_signing_response(r: requests.Response, request_type: str, msg: dict, s
             print("hash (py): {}\n".format(hash_64))
 
         # check chain
-        unpacked = msgpack.unpackb(unhexlify(r_map["upp"]))
+        unpacked = msgpack.unpackb(a2b_base64(r_map["upp"]))
         global prev_sign
         if prev_sign is not None and prev_sign != unpacked[2]:
             print(" - - - PREVIOUS SIGNATURE MISMATCH ! - - - \n")

--- a/simulation/bombard.py
+++ b/simulation/bombard.py
@@ -3,7 +3,7 @@ import json
 import random
 import sys
 import time
-from binascii import a2b_base64, b2a_base64
+from binascii import a2b_base64, b2a_base64, unhexlify
 
 import msgpack
 import requests
@@ -104,8 +104,8 @@ def check_signing_response(r: requests.Response, request_type: str, msg: dict, s
         return False
 
     if r.status_code != 200:
-        print("signing request failed! {}: ".format(r.status_code))
-        print(msgpack.unpackb(a2b_base64(r_map["response"]), raw=False)[-2])
+        print("signing request failed: {} ".format(r.status_code))
+        print("requestID: {}".format(r_map["requestID"]))
         return False
     else:
         if r_map["hash"] != hash_64:
@@ -116,7 +116,7 @@ def check_signing_response(r: requests.Response, request_type: str, msg: dict, s
             print("hash (py): {}\n".format(hash_64))
 
         # check chain
-        unpacked = msgpack.unpackb(a2b_base64(r_map["upp"]))
+        unpacked = msgpack.unpackb(unhexlify(r_map["upp"]))
         global prev_sign
         if prev_sign is not None and prev_sign != unpacked[2]:
             print(" - - - PREVIOUS SIGNATURE MISMATCH ! - - - \n")

--- a/simulation/bombard.py
+++ b/simulation/bombard.py
@@ -126,8 +126,7 @@ def check_signing_response(r: requests.Response, request_type: str, msg: dict, s
     return True
 
 
-def send_signing_request(request_type: str, msg: dict, serialized: bytes, hash_64: str,
-                         fail: bool) -> requests.Response:
+def send_signing_request(request_type: str, msg: dict, serialized: bytes, hash_64: str) -> requests.Response:
     if request_type == data_json_type:
         url, header, data = sign_data_url, json_header, json.dumps(msg)
     elif request_type == data_bin_type:
@@ -138,10 +137,6 @@ def send_signing_request(request_type: str, msg: dict, serialized: bytes, hash_6
         url, header, data = sign_hash_url, txt_header, hash_64
     else:
         raise Exception("unknown request type: " + request_type)
-
-    if fail:
-        print("SENDING REQUEST SUPPOSED TO FAIL")
-        return send_request(url=url, headers=header, data=data)
 
     return send_request(url=url, headers={**auth_header, **header}, data=data)
 
@@ -182,14 +177,13 @@ def send_verification_request(request_type: str, msg: dict, serialized: bytes, h
     return send_request(url=url, headers=header, data=data)
 
 
-fail = False
 print("\nsigning {} messages...\n".format(number_of_requests_per_type * len(types)))
 for i in range(number_of_requests_per_type):
     for t in types:
         msg = get_random_json_message()
         serialized = serialize_msg(msg)
         hash_64 = to_64(hash_bytes(serialized))
-        r = send_signing_request(t, msg, serialized, hash_64, fail)
+        r = send_signing_request(t, msg, serialized, hash_64)
         if not check_signing_response(r, t, msg, serialized, hash_64):
             failed[t] += 1
 
@@ -197,9 +191,6 @@ for i in range(number_of_requests_per_type):
         for t in types:
             print("{:3} of {} {} signing requests failed.".format(failed[t], (i + 1), t))
         print()
-        fail = True
-    else:
-        fail = False
 
 print(" max. signing duration: {} sec\n".format(max_dur))
 

--- a/simulation/bombard.py
+++ b/simulation/bombard.py
@@ -1,9 +1,9 @@
-import binascii
 import hashlib
 import json
 import secrets
 import sys
 import time
+from binascii import a2b_base64, b2a_base64
 
 import msgpack
 import requests
@@ -13,7 +13,7 @@ if len(sys.argv) < 3:
     print("python3 ./bombard.py <UUID> <AUTH_TOKEN>")
     sys.exit()
 
-num = 10
+num = 50
 uuid = sys.argv[1]
 auth = sys.argv[2]
 
@@ -35,41 +35,56 @@ bin_header = {'Content-Type': 'application/octet-stream'}
 txt_header = {'Content-Type': 'text/plain'}
 json_header = {'Content-Type': 'application/json'}
 
-letters = ("a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F", "ä", "ö", "ü", "Ä", "Ö", "Ü")
-hashes = []  # [(msg, hash, upp)]
-failed = {}
-max_dur = 0
+symbols = ("a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F",
+           "ä", "ë", "ï", "ö", "ü", "ÿ", "Ä", "Ë", "Ï", "Ö", "Ü", "Ÿ",
+           "`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=",
+           "[", "]", ";", "'", "#", ",", ".", "/", "\\",
+           "¬", "!", '''"''', "£", "$", "%", "^", "*", "(", ")", "_", "+",
+           "{", "}", ":", "@", "~", "?", " |",
+           # TODO "&", "<", ">", "&#8482",
+           "®", "™", "U+2122", "%20", "\\n", "", "\
+")
+hashes = []  # [(msg, serialized, hash, upp)]
 prev_sign = None
+max_dur = 0
+failed = {}  # init fail counter
+for t in types:
+    failed[t] = 0
 
 
-def hash_msg(msg: dict) -> (bytes, str):
-    serialized = json.dumps(msg, separators=(',', ':'), sort_keys=True, ensure_ascii=False).encode()
-    msg_hash = hashlib.sha256(serialized).digest()
-    return serialized, binascii.b2a_base64(msg_hash).decode().rstrip('\n')
+def serialize_msg(msg: dict) -> bytes:
+    return json.dumps(msg, separators=(',', ':'), sort_keys=True, ensure_ascii=False).encode()
 
 
-# generates random JSON message and returns msg_str, serialized, msg_hash
-def get_message() -> (dict, bytes, str):
+def hash_bytes(serialized: bytes) -> bytes:
+    return hashlib.sha256(serialized).digest()
+
+
+def to_64(hash_bytes: bytes) -> str:
+    return b2a_base64(hash_bytes).decode().rstrip('\n')
+
+
+# generates a random JSON message
+def get_random_jsom_message() -> dict:
     msg = {
         "id": uuid,
         "ts": int(time.time()),
         "big": secrets.randbits(53),
         "tpl": (secrets.randbits(32), secrets.randbits(8), secrets.randbits(16), secrets.randbits(4)),
         "lst": [
-            secrets.choice(letters),
-            secrets.choice(letters),
-            secrets.choice(letters),
-            secrets.choice(letters)
+            secrets.choice(symbols),
+            secrets.choice(symbols),
+            secrets.choice(symbols),
+            secrets.choice(symbols)
         ],
         "map": {
-            secrets.choice(letters): secrets.randbits(4),
-            secrets.choice(letters): secrets.randbits(16),
-            secrets.choice(letters): secrets.randbits(8),
-            secrets.choice(letters): secrets.randbits(32)
+            secrets.choice(symbols): secrets.randbits(4),
+            secrets.choice(symbols): secrets.randbits(16),
+            secrets.choice(symbols): secrets.randbits(8),
+            secrets.choice(symbols): secrets.randbits(32)
         }
     }
-    serialized, msg_hash = hash_msg(msg)
-    return msg, serialized, msg_hash
+    return msg
 
 
 def send_request(url: str, headers: dict, data: str or bytes) -> requests.Response:
@@ -81,61 +96,59 @@ def send_request(url: str, headers: dict, data: str or bytes) -> requests.Respon
     return r
 
 
-def check_signing_response(r: requests.Response, request_type: str, msg: dict, serialized: bytes, hash: str) -> bool:
+def check_signing_response(r: requests.Response, request_type: str, msg: dict, serialized: bytes, hash_64: str) -> bool:
     try:
         r_map = json.loads(r.text)
     except Exception:
-        print("client returned error: ({}) {}".format(r.status_code, r.text))
+        print("client returned error: ({}) {}\n".format(r.status_code, r.text))
         return False
 
     if r.status_code != 200:
-        print("{} signing request failed! {}: ".format(request_type, r.status_code))
-        print(msgpack.unpackb(binascii.a2b_base64(r_map["response"]), raw=False)[-2])
+        print("signing request failed! {}: ".format(r.status_code))
+        print(msgpack.unpackb(a2b_base64(r_map["response"]), raw=False)[-2])
         return False
     else:
-        if r_map["hash"] != hash:
-            print(" - - - HASH MISMATCH ! - - - ")
-            print("sorted compact json (py): {}".format(serialized.decode()))
+        if r_map["hash"] != hash_64:
+            print("- - - HASH MISMATCH: {}".format(request_type))
+            print("original: {}".format(repr(msg)))
+            print("rendered: {}".format(serialized.decode()))
             print("hash (go): {}".format(r_map["hash"]))
-            print("hash (py): {}".format(hash))
-            return False
+            print("hash (py): {}\n".format(hash_64))
 
         # check chain
-        unpacked = msgpack.unpackb(binascii.a2b_base64(r_map["upp"]))
+        unpacked = msgpack.unpackb(a2b_base64(r_map["upp"]))
         global prev_sign
         if prev_sign is not None and prev_sign != unpacked[2]:
-            print(" - - - PREVIOUS SIGNATURE MISMATCH ! - - - ")
+            print(" - - - PREVIOUS SIGNATURE MISMATCH ! - - - \n")
         prev_sign = unpacked[-1]
 
-    hashes.append((msg, hash, r_map["upp"]))  # [(msg, hash, upp)]
+    hashes.append((msg, serialized, hash_64, r_map["upp"]))  # [(msg, serialized, hash, upp)]
     return True
 
 
-def send_signing_request(request_type: str):
-    msg, serialized, hash = get_message()
-
+def send_signing_request(request_type: str, msg: dict, serialized: bytes, hash_64: str) -> requests.Response:
     if request_type == data_json_type:
         url, header, data = sign_data_url, json_header, json.dumps(msg)
     elif request_type == data_bin_type:
         url, header, data = sign_data_url, bin_header, serialized
     elif request_type == hash_bin_type:
-        url, header, data = sign_hash_url, bin_header, binascii.a2b_base64(hash)
+        url, header, data = sign_hash_url, bin_header, a2b_base64(hash_64)
     elif request_type == hash_b64_type:
-        url, header, data = sign_hash_url, txt_header, hash
+        url, header, data = sign_hash_url, txt_header, hash_64
     else:
         raise Exception("unknown request type: " + request_type)
 
-    r = send_request(url=url, headers={**auth_header, **header}, data=data)
-    if not check_signing_response(r, request_type, msg, serialized, hash):
-        failed[request_type] += 1
+    return send_request(url=url, headers={**auth_header, **header}, data=data)
 
 
-def check_verification_response(r: requests.Response, request_type: str, msg: dict, hash: str, upp: str) -> bool:
+def check_verification_response(r: requests.Response, request_type: str, msg: dict, serialized: bytes, hash_64: str,
+                                upp: str) -> bool:
     if r.status_code != 200:
-        print("NOT VERIFIED: ({})".format(request_type))
-        print("json: {}".format(repr(msg)))
-        print("hash: {}".format(hash))
-        print("response: ({}) {}".format(r.status_code, r.text))
+        print(" - - - VERIFICATION FAIL: {}".format(request_type))
+        print("original: {}".format(repr(msg)))
+        print("rendered: {}".format(serialized.decode()))
+        print("hash: {}".format(hash_64))
+        print("response: ({}) {}\n".format(r.status_code, r.text))
         return False
     else:
         r_map = json.loads(r.text)
@@ -143,57 +156,59 @@ def check_verification_response(r: requests.Response, request_type: str, msg: di
         if upp != r_map["upp"]:
             print(" - - - UPP MISMATCH ! - - - ")
             print("UPP from signing resp.: {}".format(upp))
-            print("UPP from verification resp.: {}".format(r_map["upp"]))
+            print("UPP from verification resp.: {}\n".format(r_map["upp"]))
             return False
 
     return True
 
 
-def send_verification_request(request_type: str, msg: dict, hash: str, upp: str):
+def send_verification_request(request_type: str, msg: dict, serialized: bytes, hash_64: str) -> requests.Response:
     if request_type == data_json_type:
         url, header, data = vrfy_data_url, json_header, json.dumps(msg)
     elif request_type == data_bin_type:
-        url, header, data = vrfy_data_url, bin_header, json.dumps(msg, separators=(',', ':'), sort_keys=True,
-                                                                  ensure_ascii=False).encode()
+        url, header, data = vrfy_data_url, bin_header, serialized
     elif request_type == hash_bin_type:
-        url, header, data = vrfy_hash_url, bin_header, binascii.a2b_base64(hash)
+        url, header, data = vrfy_hash_url, bin_header, a2b_base64(hash_64)
     elif request_type == hash_b64_type:
-        url, header, data = vrfy_hash_url, txt_header, hash
+        url, header, data = vrfy_hash_url, txt_header, hash_64
     else:
         raise Exception("unknown request type: " + request_type)
 
-    r = send_request(url=url, headers=header, data=data)
-    if not check_verification_response(r, request_type, msg, hash, upp):
-        failed[request_type] += 1
+    return send_request(url=url, headers=header, data=data)
 
 
-print("\nsigning {} messages...".format(num * len(types)))
-i = 0
-for t in types:
-    failed[t] = 0
-while i < num:
-    i += 1
-
+print("\nsigning {} messages...\n".format(num * len(types)))
+for i in range(num):
     for t in types:
-        send_signing_request(t)
+        msg = get_random_jsom_message()
+        serialized = serialize_msg(msg)
+        hash_64 = to_64(hash_bytes(serialized))
+        r = send_signing_request(t, msg, serialized, hash_64)
+        if not check_signing_response(r, t, msg, serialized, hash_64):
+            failed[t] += 1
 
-    if i % 10 == 0 and i != 0:
+    if (i + 1) % 10 == 0 and i != 0:
         for t in types:
-            print("{} of {} {} signing requests failed.".format(failed[t], i, t))
+            print("{:3} of {} {} signing requests failed.".format(failed[t], (i + 1), t))
+        print()
 
-print(" max. signing duration: {} sec".format(max_dur))
+print(" max. signing duration: {} sec\n".format(max_dur))
+
 max_dur = 0  # reset timer
 for t in types:  # reset fail counter
     failed[t] = 0
 
-print("\nverifying {} hashes...".format(len(hashes)))
-for i, (msg, hash, upp) in enumerate(hashes):
+print("verifying {} hashes...\n".format(len(hashes)))
+for i, (msg, serialized, hash_64, upp) in enumerate(hashes):
 
     for t in types:
-        send_verification_request(t, msg, hash, upp)
+        r = send_verification_request(t, msg, serialized, hash_64)
+        if not check_verification_response(r, t, msg, serialized, hash_64, upp):
+            failed[t] += 1
 
     if (i + 1) % 10 == 0:
         for t in types:
-            print("{} of {} {} verification requests failed.".format(failed[t], i + 1, t))
+            print("{:3} of {} {} verification requests failed.".format(failed[t], (i + 1), t))
+        print()
 
-print(" max. verification duration: {} sec".format(max_dur))
+print(" max. verification duration: {} sec\n".format(max_dur))


### PR DESCRIPTION
**WORK IN PROGRESS** 

**Changed:**
- verifier does not request public keys for verification of UPPs from unknown identities from key service by default
- enhanced error handling and logging
- verification keys of "known" identities can be injected through config

**TODOs:**
* add flag to config weather or not to retrieve verification keys of unknown identities from key service
* implement way to inject list of known identities + verification keys into local keystore on startup