### PR TITLE
UNG-1561 delete / disable / enable support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,6 @@ main/main
 
 /venv/
 /main/config.json
+/main/protocol.json
+/main/identities.json
 /main/test_config.json

--- a/README.md
+++ b/README.md
@@ -464,6 +464,7 @@ The response body consists of either an error message, or a JSON map with
 - the UPP, which contains that data hash and was sent to the UBIRCH backend by the client,
 - the response from the UBIRCH backend,
 - the unique request ID
+- *possibly:* a description of an occurred error (**the `error`-key is only present in case an error occurred**)
 
 ```json
 {
@@ -475,7 +476,8 @@ The response body consists of either an error message, or a JSON map with
     "headers": {<backend response headers (map[string][]string)>},
     "content": "<base64 encoded backend response content>"
   },
-  "requestID": "<request ID (standard hex string representation)>"
+  "requestID": "<request ID (standard hex string representation)>",
+  "error": "error message"
 }
 ```
 
@@ -504,13 +506,15 @@ The response body consists of either an error message, or a JSON map with
 - the UPP, which contains that data hash and was retrieved from the UBIRCH backend by the client,
 - the UUID of the device from which the data originated,
 - the public key of that device, which was used to verify the signature of the retrieved UPP
+- *possibly:* a description of an occurred error (**the `error`-key is only present in case an error occurred**)
 
 ```json
 {
   "hash": "<base64 encoded requested data hash>",
   "upp": "<base64 encoded UPP which was retrieved from the UBIRCH backend",
   "uuid": "<standard hex string representation of the device UUID>",
-  "pubKey": "<base64 encoded public key used for signature verification>"
+  "pubKey": "<base64 encoded public key used for signature verification>",
+  "error": "error message"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -386,12 +386,35 @@ hash injection, i.e. the SHA256 digest of the original data.
 > See [reproducibility of hashes](#reproducibility-of-hashes).
 
 To access either endpoint, an authentication token, which corresponds to the `UUID` used in the request, must be sent
-with the request header. Without it, the client won’t accept the request:
+with the request header. Without it, the client won’t accept the request.
 
-| `X-Auth-Token` | `ubirch backend token related to <UUID>` |
-|-----------------|------------------------------------------|
+| Request Header | Description |
+|----------------|------------------------------------------|
+| `X-Auth-Token` | UBIRCH backend token related to `<UUID>` |
 
 > See [how to acquire the ubirch backend token](#how-to-acquire-the-ubirch-backend-token).
+
+### Update Operations
+
+Besides achoring, the client can request hash update operations from the UBIRCH backend, i.e. `disable`, `enable`
+and `delete`.
+
+Just like for anchoring, the UBIRCH client provides HTTP endpoints for original data and direct data hash injection.
+
+| Update Operation | Path (original data)| Path (hash) |
+|------------------|---------------------|-------------|
+| disable | `/<UUID>/disable` | `/<UUID>/disable/hash` |
+| enable  | `/<UUID>/enable`  | `/<UUID>/enable/hash`  |
+| delete  | `/<UUID>/delete`  | `/<UUID>/delete/hash`  |
+
+These Endpoints also require the use of the `X-Auth-Token` request header.
+
+| Request Header | Description |
+|----------------|------------------------------------------|
+| `X-Auth-Token` | UBIRCH backend token related to `<UUID>` |
+
+Hash update requests to the UBIRCH backend must come from the same UUID that anchored said hash and be signed by the
+same private key that signed the anchoring request.
 
 ### TCP Address
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The only mandatory configurations are
 
 > See [example_config.json](main/example_config.json) as an example for file-based configuration.
 
-Besides the `devices`-map, the device UUIDs and their corresponding authentication tokens can be set through a file
+Besides the `devices`-map, the device UUIDs and their corresponding authentication tokens can also be set through a file
 "`identities.json`". See example: [example_identities.json](main/example_identities.json)
 
 ### Environment Based Configuration
@@ -368,6 +368,8 @@ the `-v $(pwd):/data` parameter can be omitted.
 
 ## Interface Description
 
+### Anchoring
+
 The UBIRCH client provides HTTP endpoints for both original data, which will be hashed by the client, and direct data
 hash injection, i.e. the SHA256 digest of the original data.
 
@@ -383,7 +385,7 @@ hash injection, i.e. the SHA256 digest of the original data.
 >
 > See [reproducibility of hashes](#reproducibility-of-hashes).
 
-To access either endpoint an authentication token, which corresponds to the `UUID` used in the request, must be sent
+To access either endpoint, an authentication token, which corresponds to the `UUID` used in the request, must be sent
 with the request header. Without it, the client won’t accept the request:
 
 | `X-Auth-Token` | `ubirch backend token related to <UUID>` |
@@ -394,9 +396,11 @@ with the request header. Without it, the client won’t accept the request:
 ### TCP Address
 
 When running the client locally, the default address is:
+
 ```fundamental
 http://localhost:8080/<UUID>
 ```
+
 (or `https://localhost:8080/<UUID>`, if TLS is enabled)
 
 > See [how to set a different TCP address/port for the client](#set-tcp-address).
@@ -430,28 +434,32 @@ considered a failure. The client does not retry itself. A good approach to handl
 original data storage that indicates whether the UBIRCH blockchain anchoring was successful and retry at a later point
 if necessary.
 
-The client's response can be either an error message, or a JSON map with the carried out operation, the data hash, the
-UPP, which contains that data hash and was sent to the UBIRCH backend, the response from the UBIRCH backend, as well as
-a unique requestID:
+The response body consists of either an error message, or a JSON map with
+
+- the carried out operation,
+- the data hash,
+- the UPP, which contains that data hash and was sent to the UBIRCH backend by the client,
+- the response from the UBIRCH backend,
+- the unique request ID
 
 ```json
 {
   "operation": "(anchor | delete | enable | disable)",
-  "hash": "<the base64 encoded data hash>",
-  "upp": "<the base64 encoded UPP containing the data hash that was sent to the ubirch backend by the client>",
+  "hash": "<base64 encoded data hash>",
+  "upp": "<base64 encoded UPP which was sent to the UBIRCH backend>",
   "response": {
-    "statusCode": "<the backend response status code>",
-    "headers": {<map with the backend response headers>},
-    "content": "<the base64 encoded backend response content>"
+    "statusCode": <backend response status code (int)>,
+    "headers": {<backend response headers (map[string][]string)>},
+    "content": "<base64 encoded backend response content>"
   },
-  "requestID": "<the request ID (standard hex string representation)>"
+  "requestID": "<request ID (standard hex string representation)>"
 }
 ```
 
 > UPPs (such as the backend response content) are [MessagePack](https://github.com/msgpack/msgpack/blob/master/spec.md) formatted
 > and can be decoded using an online tool like [this MessagePack to JSON Converter](https://toolslick.com/conversion/data/messagepack-to-json).
 
-### Verification endpoints
+### Verification
 
 The UBIRCH client also provides verification endpoints for original data and hashes.
 
@@ -467,16 +475,19 @@ There is no authentication token necessary to access the verification endpoints.
 A `200` response code indicates the successful verification of the data in the UBIRCH backend as well as a local
 verification of the validity of the retrieved UPP.
 
-The response body contains either an error message, or a JSON map with the requested data hash, the UPP, which contains
-that data hash and was retrieved from the UBIRCH backend, as well as the UUID of the device from which the data
-originated:
+The response body consists of either an error message, or a JSON map with
+
+- the requested data hash,
+- the UPP, which contains that data hash and was retrieved from the UBIRCH backend by the client,
+- the UUID of the device from which the data originated,
+- the public key of that device, which was used to verify the signature of the retrieved UPP
 
 ```json
 {
-  "hash": "<the base64 encoded requested data hash>",
-  "upp": "<the base64 encoded UPP containing the requested data hash that was retrieved from the ubirch backend by the client>",
-  "uuid": "<the standard hex string representation of the device UUID>",
-  "pubKey": "<the public key used for verification of the retrieved UPP>"
+  "hash": "<base64 encoded requested data hash>",
+  "upp": "<base64 encoded UPP which was retrieved from the UBIRCH backend",
+  "uuid": "<standard hex string representation of the device UUID>",
+  "pubKey": "<base64 encoded public key used for signature verification>"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -430,20 +430,25 @@ considered a failure. The client does not retry itself. A good approach to handl
 original data storage that indicates whether the UBIRCH blockchain anchoring was successful and retry at a later point
 if necessary.
 
-The client's response can be either an error message, or a JSON map with the anchored data hash, the UPP, which contains
-that data hash and was sent to the UBIRCH backend, the ID of the request, as well as the response from the UBIRCH
-backend, which is also a UPP:
+The client's response can be either an error message, or a JSON map with the carried out operation, the data hash, the
+UPP, which contains that data hash and was sent to the UBIRCH backend, the response from the UBIRCH backend, as well as
+a unique requestID:
 
 ```json
 {
+  "operation": "(anchor | delete | enable | disable)",
   "hash": "<the base64 encoded data hash>",
   "upp": "<the base64 encoded UPP containing the data hash that was sent to the ubirch backend by the client>",
-  "requestID": "<the base64 encoded request ID>",
-  "response": "<the base64 encoded backend response>"
+  "response": {
+    "statusCode": "<the backend response status code>",
+    "headers": {<map with the backend response headers>},
+    "content": "<the base64 encoded backend response content>"
+  },
+  "requestID": "<the request ID (standard hex string representation)>"
 }
 ```
 
-> UPPs (such as the backend response) are [MessagePack](https://github.com/msgpack/msgpack/blob/master/spec.md) formatted
+> UPPs (such as the backend response content) are [MessagePack](https://github.com/msgpack/msgpack/blob/master/spec.md) formatted
 > and can be decoded using an online tool like [this MessagePack to JSON Converter](https://toolslick.com/conversion/data/messagepack-to-json).
 
 ### Verification endpoints
@@ -470,7 +475,8 @@ originated:
 {
   "hash": "<the base64 encoded requested data hash>",
   "upp": "<the base64 encoded UPP containing the requested data hash that was retrieved from the ubirch backend by the client>",
-  "uuid": "<the standard string representation of the device UUID>"
+  "uuid": "<the standard hex string representation of the device UUID>",
+  "pubKey": "<the public key used for verification of the retrieved UPP>"
 }
 ```
 
@@ -551,7 +557,8 @@ and insignificant space characters were elided.
       "devices": {
         "<YOUR_UUID>": "<YOUR_AUTH_TOKEN>"
       },
-      "secret": "<YOUR_16_BYTE_SECRET(base64 encoded)>"
+      "secret": "<YOUR_16_BYTE_SECRET(base64 encoded)>",
+      "logTextFormat": true
     }
     ```
     - Replace `<YOUR_UUID>` with your UUID from step 1.i.
@@ -567,15 +574,15 @@ and insignificant space characters were elided.
     ```
    You should see a console output like this:
     ```console
-    INFO[2020-06-30 12:16:30.977 +0200] UBIRCH client (v2.0.0, build=local)
-    INFO[2020-06-30 12:16:30.977 +0200] loading configuration from file (config.json)
-    INFO[2020-06-30 12:16:30.977 +0200] 1 known UUID(s)
-    INFO[2020-06-30 12:16:30.977 +0200] UBIRCH backend "prod" environment
-    INFO[2020-06-30 12:16:30.977 +0200] protocol context will be saved to file: protocol.json
-    INFO[2020-06-30 12:16:31.142 +0200] generating new key pair for UUID 8a70ad8b-a564-4e58-9a3b-224ac0f0153f
-    INFO[2020-06-30 12:16:31.469 +0200] 8a70ad8b-a564-4e58-9a3b-224ac0f0153f: registering public key at key service: https://key.prod.ubirch.com/api/keyService/v1/pubkey
-    INFO[2020-06-30 12:16:31.584 +0200] 8a70ad8b-a564-4e58-9a3b-224ac0f0153f: submitting CSR to identity service: https://identity.prod.ubirch.com/api/certs/v1/csr/register
-    INFO[2020-06-30 12:16:32.842 +0200] starting HTTP service
+    {"level":"info","msg":"UBIRCH client (v2.0.0, build=local)","time":"2021-03-01T18:41:20+01:00"}
+    {"level":"info","msg":"loading configuration from file: config.json","time":"2021-03-01T18:41:20+01:00"}
+    INFO[2021-03-01 18:41:20.291 +0100] 1 known UUID(s)
+    INFO[2021-03-01 18:41:20.291 +0100] UBIRCH backend "prod" environment
+    INFO[2021-03-01 18:41:20.291 +0100] protocol context will be saved to file: protocol.json
+    INFO[2021-03-01 18:41:20.291 +0100] generating new key pair for UUID 50b1a5bb-83cd-4251-b674-b3c71a058fc3
+    INFO[2021-03-01 18:41:20.664 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: registering public key at key service: https://key.prod.ubirch.com/api/keyService/v1/pubkey
+    INFO[2021-03-01 18:41:21.755 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: submitting CSR to identity service: https://identity.prod.ubirch.com/api/certs/v1/csr/register
+    INFO[2021-03-01 18:41:22.130 +0100] starting HTTP service
     ```
    That means the client is running and ready!
 
@@ -593,32 +600,52 @@ and insignificant space characters were elided.
 
    Here is an example of how a request to the client would look like using `CURL`:
    ```console
-   curl -H "X-Auth-Token: <YOUR_AUTH_TOKEN>" -H "Content-Type: application/json" -d '{"id": "605b91b4-49be-4f17-93e7-f1b14384968f", "ts": 1585838578, "data": "1234567890"}' localhost:8080/<YOUR_UUID> -i -s
+   curl -H "X-Auth-Token: <YOUR_AUTH_TOKEN>" -H "Content-Type: application/json" -d '{"id": "50b1a5bb-83cd-4251-b674-b3c71a058fc3", "ts": 1614621028, "data": "1234567890"}' localhost:8080/<YOUR_UUID> -i -s
    ```
    > Insert `<YOUR_AUTH_TOKEN>` and `<YOUR_UUID>` and a request body with your own unique content to ensure a unique hash!
 
    When the client receives the request, the output should look like this:
-   ```console
-   INFO[2020-06-30 12:17:31.584 +0200] 8a70ad8b-a564-4e58-9a3b-224ac0f0153f: signing hash: bTawDQO7nnB+3h55/6VyQ+Tmd1RTV9R0cFcf7CRWzQQ=
-   ```
+    ```console
+    INFO[2021-03-01 18:52:59.471 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: anchoring hash: CDUvtOIBnnZ8im/UXQn5G/q5EK9l2Bqy+HyMgSzPZoA=
+    INFO[2021-03-01 18:53:00.313 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: request ID: 0f11686e-aee3-4e97-8d0d-793a0c31d969
+    ```
    > Take note of the hash!
 
    If your request was submitted, you'll get a `200` response code.
 
-   The HTTP response body from the client is a JSON map containing the data hash and the UPP, that has been sent to the
-   UBIRCH backend, and the response from the backend, which is a UPP as well. UPPs are in *MessagePack* format.
+   The HTTP response body from the client is a JSON map containing the carried out operation, the data hash, the UPP,
+   which was sent to the UBIRCH backend, and the backend response, of which the content is also a UPP, UPPs are in *
+   MessagePack* format (base64 encoded) and can be decoded using, for example, this
+   [MessagePack to JSON Converter](https://toolslick.com/conversion/data/messagepack-to-json).
 
    ```json
     {
-      "hash": "bTawDQO7nnB+3h55/6VyQ+Tmd1RTV9R0cFcf7CRWzQQ=",
-      "requestID": "7fZH8yVcT0apq4Pnu5sdVw==",
-      "response": "liPEEJ08eP8i80RBpdGFxjbUhv/EQPgwxioCe/xc+22gjjvULF32Q+zZNDosE0msmzyppKHihm2a7wb7g3VJoXg2UhpM4xS87kAapI+m+QRONig9bIkAgadtZXNzYWdlv3lvdXIgcmVxdWVzdCBoYXMgYmVlbiBzdWJtaXR0ZWTEQP/3P6UH0G8qY5t9bdSjroKVI4N5KScCHKJ9xsoHhesLLv9dCgdD0UoGvc/Mg9x0PGHKVoxKBwPs1v95+M+EQQQ=",
-      "upp": "liPEEPfutp5U60IAt/7nLuSggtLEQPgwxioCe/xc+22gjjvULF32Q+zZNDosE0msmzyppKHihm2a7wb7g3VJoXg2UhpM4xS87kAapI+m+QRONig9bIkAxCBtNrANA7uecH7eHnn/pXJD5OZ3VFNX1HRwVx/sJFbNBMRAZqKMnYa7nuyfmyV1dAUxwBvXG3fdZYUxyRE+mfeC/GWDwNXE4Tga5iauFfzOaULeNcUR2msAzwcL0FObMZaNaw=="
+        "operation": "anchor",
+        "hash": "CDUvtOIBnnZ8im/UXQn5G/q5EK9l2Bqy+HyMgSzPZoA=",
+        "upp": "liPEEFCxpbuDzUJRtnSzxxoFj8PEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxCAINS+04gGednyKb9RdCfkb+rkQr2XYGrL4fIyBLM9mgMRAIVlhgxobRl7ApJerXUyJ5cBxBJJ7gwPUN9AKgKJWxAxkWMWufRp8jW9Ha79s5hYbNp9+bn94cMflWyAyyjy4Ew==",
+        "response": {
+            "statusCode": 200,
+            "headers": {
+                "Content-Length": [
+                    "187"
+                ],
+                "Content-Type": [
+                    "application/octet-stream"
+                ],
+                "Date": [
+                    "Mon, 01 Mar 2021 17:53:00 GMT"
+                ],
+                "Server": [
+                    "ubirch-trust-service/1.0"
+                ]
+            },
+            "content": "liPEEJ08eP8i80RBpdGFxjbUhv/EQCFZYYMaG0ZewKSXq11MieXAcQSSe4MD1DfQCoCiVsQMZFjFrn0afI1vR2u/bOYWGzaffm5/eHDH5VsgMso8uBMAxCAPEWhuruNOl40NeToMMdlpAAAAAAAAAAAAAAAAAAAAAMRA+IFgAugN6CY1xPSch1TwhFdac8yRA1QhPRXOhUt7rudrwrNv0NAEJGlLw1wUSpcSLmBFQaoRb9EezmYxmtF7iA=="
+        },
+        "requestID": "0f11686e-aee3-4e97-8d0d-793a0c31d969"
     }
    ```
-   If you get a response code other than `200`, it means that something went wrong. To check the error message, decode
-   the `"response"`-UPP from the backend using
-   the [MessagePack to JSON Converter](https://toolslick.com/conversion/data/messagepack-to-json).
+   If you get a response code other than `200`, it means that something went wrong. In this case the client will respond
+   with an error message. You can also find error messages in the console output of the client.
 
 1. To stop the client, press `ctrl` + `c`.
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,16 @@ The client will first look if the `UBIRCH_SECRET` env variable exists and load t
 variables in that case. If the `UBIRCH_SECRET` env variable is not set or empty, and the `config.json`-file exists in
 the working directory, the configuration will be loaded from the file. If neither exist, the client will abort and exit.
 
-The only two mandatory configurations are
+The only mandatory configurations are
 
-- the `devices`-map, which maps device UUIDs to their authentication token
-  > - A UUID can be generated in a Linux/macOS terminal with the `uuidgen` command
-  > - See [how to acquire the authentication token](#how-to-acquire-the-ubirch-backend-token)
-- the 16 byte base64 encoded `secret`, which is used to encrypt the key store.
-  > Quickly generate a random 16 byte base64 encoded secret in a Linux/macOS terminal with `head -c 16 /dev/urandom | base64`
+1. the `devices`-map, which maps device UUIDs to their authentication token
+
+> - A UUID can be generated in a Linux/macOS terminal with the `uuidgen` command
+> - See [here](#how-to-acquire-the-ubirch-backend-token) how to acquire the authentication token
+
+2. the 16 byte base64 encoded `secret`, which is used to encrypt the key store
+
+> Quickly generate a random 16 byte base64 encoded secret in a Linux/macOS terminal with `head -c 16 /dev/urandom | base64`
 
 ### File Based Configuration
 
@@ -105,7 +108,10 @@ The only two mandatory configurations are
 }
 ```
 
-(See [example_config.json](main/example_config.json) for an example.)
+> See [example_config.json](main/example_config.json) as an example for file-based configuration.
+
+Besides the `devices`-map, the device UUIDs and their corresponding authentication tokens can be set through a file
+"`identities.json`". See example: [example_identities.json](main/example_identities.json)
 
 ### Environment Based Configuration
 
@@ -114,7 +120,7 @@ UBIRCH_DEVICES=<UUID>:<ubirch backend auth token>
 UBIRCH_SECRET=<16 byte secret used to encrypt the key store (base64 encoded)>
 ```
 
-(See [example.env](main/example.env) for an example.)
+> See [example.env](main/example.env) as an example for environment-based configuration.
 
 All other configuration parameters have default values, but can be configured as follows.
 
@@ -125,7 +131,8 @@ environment. For development, the environment may be set to `demo`, which is a t
 production environment, but stores data only in a blockchain test net. __However, we suggest using `prod` in general as demo
 may not always be available__.
 
-> Note that the UUIDs must be registered at the according UBIRCH backend environment.
+> Note that the UUIDs must be registered at the according UBIRCH backend environment,
+> i.e. https://console.demo.ubirch.com/.
 
 To switch to the `demo` backend environment
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ the working directory, the configuration will be loaded from the file. If neithe
 The only two mandatory configurations are
 
 - the `devices`-map, which maps device UUIDs to their authentication token
-  > - A UUID can be generated in a Linux terminal with the `uuidgen` command
+  > - A UUID can be generated in a Linux/macOS terminal with the `uuidgen` command
   > - See [how to acquire the authentication token](#how-to-acquire-the-ubirch-backend-token)
 - the 16 byte base64 encoded `secret`, which is used to encrypt the key store.
-  > Quickly generate a random 16 byte base64 encoded secret in a Linux terminal with `head -c 16 /dev/urandom | base64`
+  > Quickly generate a random 16 byte base64 encoded secret in a Linux/macOS terminal with `head -c 16 /dev/urandom | base64`
 
 ### File Based Configuration
 
@@ -322,16 +322,13 @@ UBIRCH_DEBUG=true
 
 ### How to acquire the ubirch backend token
 
-- Register at the **UBIRCH web UI**:
-
-  Depending on the UBIRCH backend environment you are using, go to
-    - `prod`: [https://console.prod.ubirch.com/](https://console.prod.ubirch.com/)
-    - `demo`: [https://console.demo.ubirch.com/](https://console.demo.ubirch.com/)
+- Create an account at the [**UBIRCH web UI**](https://console.prod.ubirch.com/) and log in
 - Go to **Things** (in the menu on the left) and click on `+ ADD NEW DEVICE`
-- Enter your device UUID to the **ID** field. You can also add a description for your device, if you want. Then click
-  on `register`.
-- Your device should now show up under **Your Things**-overview. Click on it and copy the "password" (which looks like a
-  UUID) as the ubirch backend token.
+- Enter your UUID to the **ID** field. You can also add a description if you want. Then click on `register`.
+- Your UUID should now show up under the **Your Things**-overview. Click on it and copy the "password" (which looks like
+  a UUID) from the `apiConfig`. This is the UBIRCH backend token needed for the configuration of the client.
+
+[Jump back to Configuration](#configuration)
 
 ## Run Client in Docker container
 

--- a/main/client.go
+++ b/main/client.go
@@ -79,8 +79,8 @@ func getSignedCertificate(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte) ([]
 }
 
 // post submits a message to a backend service
-// returns the response status code, body and headers and encountered errors
-func post(url string, data []byte, headers map[string]string) (HTTPResponse, error) {
+// returns the response or encountered errors
+func post(url string, data []byte, header map[string]string) (HTTPResponse, error) {
 	client := &http.Client{Timeout: 60 * time.Second}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
@@ -88,7 +88,7 @@ func post(url string, data []byte, headers map[string]string) (HTTPResponse, err
 		return HTTPResponse{}, fmt.Errorf("can't make new post request: %v", err)
 	}
 
-	for k, v := range headers {
+	for k, v := range header {
 		req.Header.Set(k, v)
 	}
 
@@ -103,7 +103,7 @@ func post(url string, data []byte, headers map[string]string) (HTTPResponse, err
 	respBodyBytes, err := ioutil.ReadAll(resp.Body)
 	return HTTPResponse{
 		StatusCode: resp.StatusCode,
-		Headers:    resp.Header,
+		Header:     resp.Header,
 		Content:    respBodyBytes,
 	}, err
 }

--- a/main/client.go
+++ b/main/client.go
@@ -78,6 +78,14 @@ func getSignedCertificate(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte) ([]
 	return json.Marshal(cert)
 }
 
+func ubirchHeader(uid uuid.UUID, auth string) map[string]string {
+	return map[string]string{
+		"x-ubirch-hardware-id": uid.String(),
+		"x-ubirch-auth-type":   "ubirch",
+		"x-ubirch-credential":  base64.StdEncoding.EncodeToString([]byte(auth)),
+	}
+}
+
 // post submits a message to a backend service
 // returns the response or encountered errors
 func post(url string, data []byte, header map[string]string) (HTTPResponse, error) {

--- a/main/client.go
+++ b/main/client.go
@@ -81,7 +81,7 @@ func getSignedCertificate(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte) ([]
 // post submits a message to a backend service
 // returns the response status code, body and headers and encountered errors
 func post(url string, data []byte, headers map[string]string) (int, []byte, http.Header, error) {
-	client := &http.Client{}
+	client := &http.Client{Timeout: 120 * time.Second}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	if err != nil {

--- a/main/client.go
+++ b/main/client.go
@@ -102,9 +102,9 @@ func post(url string, data []byte, headers map[string]string) (HTTPResponse, err
 
 	respBodyBytes, err := ioutil.ReadAll(resp.Body)
 	return HTTPResponse{
-		Code:    resp.StatusCode,
-		Headers: resp.Header,
-		Content: respBodyBytes,
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header,
+		Content:    respBodyBytes,
 	}, err
 }
 

--- a/main/client.go
+++ b/main/client.go
@@ -80,12 +80,12 @@ func getSignedCertificate(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte) ([]
 
 // post submits a message to a backend service
 // returns the response status code, body and headers and encountered errors
-func post(url string, data []byte, headers map[string]string) (int, []byte, http.Header, error) {
+func post(url string, data []byte, headers map[string]string) (HTTPResponse, error) {
 	client := &http.Client{Timeout: 120 * time.Second}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	if err != nil {
-		return 0, nil, nil, fmt.Errorf("can't make new post request: %v", err)
+		return HTTPResponse{}, fmt.Errorf("can't make new post request: %v", err)
 	}
 
 	for k, v := range headers {
@@ -94,14 +94,18 @@ func post(url string, data []byte, headers map[string]string) (int, []byte, http
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, nil, nil, err
+		return HTTPResponse{}, err
 	}
 
 	//noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 
 	respBodyBytes, err := ioutil.ReadAll(resp.Body)
-	return resp.StatusCode, respBodyBytes, resp.Header, err
+	return HTTPResponse{
+		Code:    resp.StatusCode,
+		Headers: resp.Header,
+		Content: respBodyBytes,
+	}, err
 }
 
 // requestPublicKeys requests a devices public keys at the identity service

--- a/main/client.go
+++ b/main/client.go
@@ -81,7 +81,7 @@ func getSignedCertificate(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte) ([]
 // post submits a message to a backend service
 // returns the response status code, body and headers and encountered errors
 func post(url string, data []byte, headers map[string]string) (HTTPResponse, error) {
-	client := &http.Client{Timeout: 120 * time.Second}
+	client := &http.Client{Timeout: 60 * time.Second}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
 	if err != nil {

--- a/main/config.go
+++ b/main/config.go
@@ -65,7 +65,7 @@ type Config struct {
 	CORS_Origins     []string          `json:"CORS_origins"`     // list of allowed origin hosts, defaults to ["*"]
 	Debug            bool              `json:"debug"`            // enable extended debug output, defaults to 'false'
 	LogTextFormat    bool              `json:"logTextFormat"`    // log in text format for better human readability, default format is JSON
-	SecretBytes      []byte            // the decoded key store secret
+	SecretBytes      []byte            // the decoded key store secret (set automatically)
 	KeyService       string            // key service URL (set automatically)
 	IdentityService  string            // identity service URL (set automatically)
 	Niomon           string            // authentication service URL (set automatically)

--- a/main/example.env
+++ b/main/example.env
@@ -1,6 +1,6 @@
 UBIRCH_DEVICES=e1aead08-1fcb-47b3-bf2c-d3343cb979da:cefa0c34-8448-44f2-9330-27c66519a2d3,8a70ad8b-a564-4e58-9a3b-224ac0f0153f:f728ddb3-d504-4925-b216-b7842a2f1a6b
 UBIRCH_SECRET=MTIzNDU2Nzg5MDEyMzQ1Ng==
-UBIRCH_ENV=demo
+UBIRCH_ENV=prod
 UBIRCH_DSN=postgres://username:password@hostname:5432/database?sslmode=disable
 UBIRCH_STATICKEYS=false
 UBIRCH_KEYS=e1aead08-1fcb-47b3-bf2c-d3343cb979da:ZCJEojZraAqDJFPUxYR4saxkwM222tnLdd6MbRMtLKs=,8a70ad8b-a564-4e58-9a3b-224ac0f0153f:/yvKyc+hrO0HXlXq3eoofw7m85P1zZIiZ+l2UpExz1I=

--- a/main/example_config.json
+++ b/main/example_config.json
@@ -4,7 +4,7 @@
     "8a70ad8b-a564-4e58-9a3b-224ac0f0153f": "f728ddb3-d504-4925-b216-b7842a2f1a6b"
   },
   "secret": "MTIzNDU2Nzg5MDEyMzQ1Ng==",
-  "env": "demo",
+  "env": "prod",
   "DSN": "postgres://username:password@hostname:5432/database?sslmode=disable",
   "staticKeys": false,
   "keys": {

--- a/main/example_identities.json
+++ b/main/example_identities.json
@@ -1,0 +1,10 @@
+[
+  {
+    "uuid": "e1aead08-1fcb-47b3-bf2c-d3343cb979da",
+    "password": "cefa0c34-8448-44f2-9330-27c66519a2d3"
+  },
+  {
+    "uuid": "8a70ad8b-a564-4e58-9a3b-224ac0f0153f",
+    "password": "f728ddb3-d504-4925-b216-b7842a2f1a6b"
+  }
+]

--- a/main/go.mod
+++ b/main/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310142034-e8ac5a190992
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/main/go.mod
+++ b/main/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310142034-e8ac5a190992
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310233515-4e2042e57805
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/main/go.mod
+++ b/main/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubirch/ubirch-client-go/main
 
-go 1.13
+go 1.16
 
 require (
 	github.com/go-chi/chi v4.1.0+incompatible
@@ -10,6 +10,6 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/main/go.sum
+++ b/main/go.sum
@@ -28,6 +28,8 @@ github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5 h1:7sOjpGo+kBmvyOEEiQ6Uqpq
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5/go.mod h1:nTqN+niHQNN5XLxMgd5MOD+yW9vBi9trYIj4vBuVi2Y=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4 h1:k0jRFHRIbYBw938zYvsiDf8U0SyKClmko2+86voTZHw=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310142034-e8ac5a190992 h1:6R2Kei+dI2rW3JknIAp6ZcTJtJheKhn7Zl/n6RBD1mM=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310142034-e8ac5a190992/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/go.sum
+++ b/main/go.sum
@@ -26,6 +26,8 @@ github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IK
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5 h1:7sOjpGo+kBmvyOEEiQ6UqpqlLZzybdij3oxDz5uCSXM=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5/go.mod h1:nTqN+niHQNN5XLxMgd5MOD+yW9vBi9trYIj4vBuVi2Y=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4 h1:k0jRFHRIbYBw938zYvsiDf8U0SyKClmko2+86voTZHw=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/go.sum
+++ b/main/go.sum
@@ -30,6 +30,8 @@ github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4 h1:k0jRFHRIbYBw938zYvsiDf8
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310142034-e8ac5a190992 h1:6R2Kei+dI2rW3JknIAp6ZcTJtJheKhn7Zl/n6RBD1mM=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310142034-e8ac5a190992/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310233515-4e2042e57805 h1:1wK1vzvzNnnY3+pfXHqcsk/D8JW+sKsN31wXvfeJ4mk=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310233515-4e2042e57805/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/go.sum
+++ b/main/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -24,12 +23,6 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IKw=
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5 h1:7sOjpGo+kBmvyOEEiQ6UqpqlLZzybdij3oxDz5uCSXM=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.1.5/go.mod h1:nTqN+niHQNN5XLxMgd5MOD+yW9vBi9trYIj4vBuVi2Y=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4 h1:k0jRFHRIbYBw938zYvsiDf8U0SyKClmko2+86voTZHw=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.4/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310142034-e8ac5a190992 h1:6R2Kei+dI2rW3JknIAp6ZcTJtJheKhn7Zl/n6RBD1mM=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310142034-e8ac5a190992/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310233515-4e2042e57805 h1:1wK1vzvzNnnY3+pfXHqcsk/D8JW+sKsN31wXvfeJ4mk=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310233515-4e2042e57805/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -44,9 +44,9 @@ type HTTPMessage struct {
 }
 
 type HTTPResponse struct {
-	Code    int
-	Headers map[string][]string
-	Content []byte
+	Code    int         `json:"statusCode"`
+	Headers http.Header `json:"headers"`
+	Content []byte      `json:"content"`
 }
 
 // wrapper for http.Error that additionally logs the error message to std.Output
@@ -318,7 +318,7 @@ func HTTPErrorResponse(code int, message string) HTTPResponse {
 	log.Error(message)
 	return HTTPResponse{
 		Code:    code,
-		Headers: map[string][]string{"Content-Type": {"text/plain; charset=utf-8"}},
+		Headers: http.Header{"Content-Type": {"text/plain; charset=utf-8"}},
 		Content: []byte(message),
 	}
 }

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -332,9 +332,9 @@ func (srv *HTTPServer) Serve(ctx context.Context) error {
 	server := &http.Server{
 		Addr:         srv.addr,
 		Handler:      srv.router,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 75 * time.Second,
-		IdleTimeout:  90 * time.Second,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 90 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 
 	go func() {

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -47,7 +47,7 @@ type HTTPRequest struct {
 
 type HTTPResponse struct {
 	StatusCode int         `json:"statusCode"`
-	Headers    http.Header `json:"headers"`
+	Header     http.Header `json:"header"`
 	Content    []byte      `json:"content"`
 }
 
@@ -152,12 +152,12 @@ func Error(w http.ResponseWriter, err error, code int) {
 	http.Error(w, err.Error(), code)
 }
 
-// helper function to get "Content-Type" from request headers
+// helper function to get "Content-Type" from request header
 func ContentType(header http.Header) string {
 	return strings.ToLower(header.Get("Content-Type"))
 }
 
-// helper function to get "X-Auth-Token" from request headers
+// helper function to get "X-Auth-Token" from request header
 func AuthToken(header http.Header) string {
 	return header.Get("X-Auth-Token")
 }
@@ -297,7 +297,7 @@ func sendResponseChannel(w http.ResponseWriter, respChan chan HTTPResponse) {
 
 // forwards response to sender
 func sendResponse(w http.ResponseWriter, resp HTTPResponse) {
-	for k, v := range resp.Headers {
+	for k, v := range resp.Header {
 		w.Header().Set(k, v[0])
 	}
 	w.WriteHeader(resp.StatusCode)

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -45,9 +45,9 @@ type HTTPMessage struct {
 }
 
 type HTTPResponse struct {
-	Code    int         `json:"statusCode"`
-	Headers http.Header `json:"headers"`
-	Content []byte      `json:"content"`
+	StatusCode int         `json:"statusCode"`
+	Headers    http.Header `json:"headers"`
+	Content    []byte      `json:"content"`
 }
 
 type Service interface {
@@ -233,7 +233,7 @@ func sendResponse(w http.ResponseWriter, resp HTTPResponse) {
 	for k, v := range resp.Headers {
 		w.Header().Set(k, v[0])
 	}
-	w.WriteHeader(resp.Code)
+	w.WriteHeader(resp.StatusCode)
 	_, err := w.Write(resp.Content)
 	if err != nil {
 		log.Errorf("unable to write response: %s", err)
@@ -381,8 +381,8 @@ func HTTPErrorResponse(code int, message string) HTTPResponse {
 	}
 	log.Error(message)
 	return HTTPResponse{
-		Code:    code,
-		Headers: http.Header{"Content-Type": {"text/plain; charset=utf-8"}},
-		Content: []byte(message),
+		StatusCode: code,
+		Headers:    http.Header{"Content-Type": {"text/plain; charset=utf-8"}},
+		Content:    []byte(message),
 	}
 }

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -39,7 +39,7 @@ type ServerEndpoint struct {
 
 type HTTPRequest struct {
 	ID        uuid.UUID
-	Auth      []byte
+	Auth      string
 	Hash      Sha256Sum
 	Operation operation
 	Response  chan HTTPResponse
@@ -174,20 +174,20 @@ func getUUID(r *http.Request) (uuid.UUID, error) {
 
 // checkAuth checks the auth token from the request header and returns it if valid
 // Returns error if UUID is unknown or auth token is invalid
-func checkAuth(r *http.Request, id uuid.UUID, authTokens map[string]string) ([]byte, error) {
+func checkAuth(r *http.Request, id uuid.UUID, authTokens map[string]string) (string, error) {
 	// check if UUID is known
 	idAuthToken, exists := authTokens[id.String()]
 	if !exists || idAuthToken == "" {
-		return nil, fmt.Errorf("unknown UUID: \"%s\"", id.String())
+		return "", fmt.Errorf("unknown UUID: \"%s\"", id.String())
 	}
 
 	// check auth token from request header
 	headerAuthToken := AuthToken(r.Header)
 	if idAuthToken != headerAuthToken {
-		return nil, fmt.Errorf("invalid auth token")
+		return "", fmt.Errorf("invalid auth token")
 	}
 
-	return []byte(headerAuthToken), nil
+	return headerAuthToken, nil
 }
 
 // getOperation returns the operation parameter from the request URL

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -374,15 +374,3 @@ func (srv *HTTPServer) Serve(ctx context.Context) error {
 	}
 	return nil
 }
-
-func HTTPErrorResponse(code int, message string) HTTPResponse {
-	if message == "" {
-		message = http.StatusText(code)
-	}
-	log.Error(message)
-	return HTTPResponse{
-		StatusCode: code,
-		Headers:    http.Header{"Content-Type": {"text/plain; charset=utf-8"}},
-		Content:    []byte(message),
-	}
-}

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -194,11 +194,11 @@ func checkAuth(r *http.Request, id uuid.UUID, authTokens map[string]string) ([]b
 func getOperation(r *http.Request) (operation, error) {
 	opParam := chi.URLParam(r, OperationKey)
 	switch operation(opParam) {
-	case deleteHash, enableHash, disableHash:
+	case disableHash, enableHash, deleteHash:
 		return operation(opParam), nil
 	default:
 		return "", fmt.Errorf("invalid update operation: "+
-			"expected (\"%s\" | \"%s\" | \"%s\"), got \"%s\"", deleteHash, enableHash, disableHash, opParam)
+			"expected (\"%s\" | \"%s\" | \"%s\"), got \"%s\"", disableHash, enableHash, deleteHash, opParam)
 	}
 }
 

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path"
 	"strings"
 	"time"
 
@@ -136,7 +137,6 @@ func getUUID(r *http.Request) (uuid.UUID, error) {
 	if err != nil {
 		return uuid.Nil, fmt.Errorf("unable to parse \"%s\" as UUID: %s", urlParam, err)
 	}
-
 	return id, nil
 }
 
@@ -331,11 +331,13 @@ func (srv *HTTPServer) SetUpCORS(allowedOrigins []string, debug bool) {
 }
 
 func (srv *HTTPServer) AddEndpoint(endpoint ServerEndpoint) {
+	hashEndpointPath := path.Join(endpoint.Path + "/hash")
+
 	srv.router.Post(endpoint.Path, endpoint.handleRequestOriginalData)
-	srv.router.Post(endpoint.Path+"/hash", endpoint.handleRequestHash)
+	srv.router.Post(hashEndpointPath, endpoint.handleRequestHash)
 
 	srv.router.Options(endpoint.Path, endpoint.handleOptions)
-	srv.router.Options(endpoint.Path+"/hash", endpoint.handleOptions)
+	srv.router.Options(hashEndpointPath, endpoint.handleOptions)
 }
 
 func (srv *HTTPServer) Serve(ctx context.Context) error {

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -33,8 +33,8 @@ const (
 type Sha256Sum [HashLen]byte
 
 type ServerEndpoint struct {
-	Path    string
-	Service Service
+	Path string
+	Service
 }
 
 type HTTPRequest struct {
@@ -56,17 +56,17 @@ type Service interface {
 }
 
 type AnchoringService struct {
-	Signer
+	*Signer
 	AuthTokens map[string]string
 }
 
 type UpdateOperationService struct {
-	Signer
+	*Signer
 	AuthTokens map[string]string
 }
 
 type VerificationService struct {
-	Verifier
+	*Verifier
 }
 
 func (service *AnchoringService) handleRequest(w http.ResponseWriter, r *http.Request) {
@@ -307,7 +307,7 @@ func sendResponse(w http.ResponseWriter, resp HTTPResponse) {
 	}
 }
 
-func (endpnt *ServerEndpoint) handleOptions(w http.ResponseWriter, r *http.Request) {
+func (*ServerEndpoint) handleOptions(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
@@ -341,8 +341,8 @@ func (srv *HTTPServer) SetUpCORS(allowedOrigins []string, debug bool) {
 func (srv *HTTPServer) AddEndpoint(endpoint ServerEndpoint) {
 	hashEndpointPath := path.Join(endpoint.Path + HashEndpoint)
 
-	srv.router.Post(endpoint.Path, endpoint.Service.handleRequest)
-	srv.router.Post(hashEndpointPath, endpoint.Service.handleRequest)
+	srv.router.Post(endpoint.Path, endpoint.handleRequest)
+	srv.router.Post(hashEndpointPath, endpoint.handleRequest)
 
 	srv.router.Options(endpoint.Path, endpoint.handleOptions)
 	srv.router.Options(hashEndpointPath, endpoint.handleOptions)

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -31,7 +31,7 @@ func registerPublicKey(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte, keySer
 	}
 	log.Debugf("%s: certificate: %s", uid.String(), cert)
 
-	code, resp, _, err := post(keyService, cert, map[string]string{
+	resp, err := post(keyService, cert, map[string]string{
 		"content-type":         "application/json",
 		"x-ubirch-hardware-id": uid.String(),
 		"x-ubirch-auth-type":   "ubirch",
@@ -40,12 +40,10 @@ func registerPublicKey(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte, keySer
 	if err != nil {
 		return fmt.Errorf("error sending key registration: %v", err)
 	}
-	if httpFailed(code) {
-		return fmt.Errorf("request to %s failed: (%d) %s", keyService, code, string(resp))
+	if httpFailed(resp.Code) {
+		return fmt.Errorf("request to %s failed: (%d) %q", keyService, resp.Code, resp.Content)
 	}
-
-	log.Debugf("%s: key registration successful: (%d) %s", uid.String(), code, string(resp))
-
+	log.Debugf("%s: key registration successful: (%d) %s", uid.String(), resp.Code, string(resp.Content))
 	return nil
 }
 
@@ -59,16 +57,14 @@ func submitCSR(p *ExtendedProtocol, uid uuid.UUID, subjectCountry string, subjec
 	}
 	log.Debugf("%s: CSR [der]: %s", uid.String(), hex.EncodeToString(csr))
 
-	code, resp, _, err := post(identityService, csr, map[string]string{"Content-Type": "application/octet-stream"})
+	resp, err := post(identityService, csr, map[string]string{"Content-Type": "application/octet-stream"})
 	if err != nil {
 		return fmt.Errorf("error sending CSR: %v", err)
 	}
-	if httpFailed(code) {
-		return fmt.Errorf("request to %s failed: (%d) %s", identityService, code, string(resp))
+	if httpFailed(resp.Code) {
+		return fmt.Errorf("request to %s failed: (%d) %q", identityService, resp.Code, resp.Content)
 	}
-
-	log.Debugf("%s: CSR submitted: (%d) %s", uid.String(), code, string(resp))
-
+	log.Debugf("%s: CSR submitted: (%d) %s", uid.String(), resp.Code, string(resp.Content))
 	return nil
 }
 

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -40,10 +40,10 @@ func registerPublicKey(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte, keySer
 	if err != nil {
 		return fmt.Errorf("error sending key registration: %v", err)
 	}
-	if httpFailed(resp.Code) {
-		return fmt.Errorf("request to %s failed: (%d) %q", keyService, resp.Code, resp.Content)
+	if httpFailed(resp.StatusCode) {
+		return fmt.Errorf("request to %s failed: (%d) %q", keyService, resp.StatusCode, resp.Content)
 	}
-	log.Debugf("%s: key registration successful: (%d) %s", uid.String(), resp.Code, string(resp.Content))
+	log.Debugf("%s: key registration successful: (%d) %s", uid.String(), resp.StatusCode, string(resp.Content))
 	return nil
 }
 
@@ -61,10 +61,10 @@ func submitCSR(p *ExtendedProtocol, uid uuid.UUID, subjectCountry string, subjec
 	if err != nil {
 		return fmt.Errorf("error sending CSR: %v", err)
 	}
-	if httpFailed(resp.Code) {
-		return fmt.Errorf("request to %s failed: (%d) %q", identityService, resp.Code, resp.Content)
+	if httpFailed(resp.StatusCode) {
+		return fmt.Errorf("request to %s failed: (%d) %q", identityService, resp.StatusCode, resp.Content)
 	}
-	log.Debugf("%s: CSR submitted: (%d) %s", uid.String(), resp.Code, string(resp.Content))
+	log.Debugf("%s: CSR submitted: (%d) %s", uid.String(), resp.StatusCode, string(resp.Content))
 	return nil
 }
 

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"github.com/google/uuid"
@@ -31,12 +30,10 @@ func registerPublicKey(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte, keySer
 	}
 	log.Debugf("%s: certificate: %s", uid.String(), cert)
 
-	resp, err := post(keyService, cert, map[string]string{
-		"content-type":         "application/json",
-		"x-ubirch-hardware-id": uid.String(),
-		"x-ubirch-auth-type":   "ubirch",
-		"x-ubirch-credential":  base64.StdEncoding.EncodeToString([]byte(auth)),
-	})
+	keyRegHeader := ubirchHeader(uid, auth)
+	keyRegHeader["content-type"] = "application/json"
+
+	resp, err := post(keyService, cert, keyRegHeader)
 	if err != nil {
 		return fmt.Errorf("error sending key registration: %v", err)
 	}
@@ -57,7 +54,9 @@ func submitCSR(p *ExtendedProtocol, uid uuid.UUID, subjectCountry string, subjec
 	}
 	log.Debugf("%s: CSR [der]: %s", uid.String(), hex.EncodeToString(csr))
 
-	resp, err := post(identityService, csr, map[string]string{"Content-Type": "application/octet-stream"})
+	CSRHeader := map[string]string{"content-type": "application/octet-stream"}
+
+	resp, err := post(identityService, csr, CSRHeader)
 	if err != nil {
 		return fmt.Errorf("error sending CSR: %v", err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -152,18 +152,15 @@ func main() {
 		return httpServer.Serve(ctx)
 	})
 
-	//wait until all function calls from the Go method have returned
-	if err = waitUntilDone(g, &p); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func waitUntilDone(g *errgroup.Group, p *ExtendedProtocol) error {
-	groupErr := g.Wait()
-
-	if err := p.Deinit(); err != nil {
+	// wait for all go routines of the waitgroup to return
+	if err = g.Wait(); err != nil {
 		log.Error(err)
 	}
 
-	return groupErr
+	log.Info("shutting down client")
+
+	// wrap up
+	if err = p.Deinit(); err != nil {
+		log.Error(err)
+	}
 }

--- a/main/main.go
+++ b/main/main.go
@@ -123,26 +123,10 @@ func main() {
 		AuthTokens:   conf.Devices,
 	})
 
-	// set up deleting endpoint
+	// set up endpoint for hash operations
 	httpServer.AddEndpoint(ServerEndpoint{
-		Path:         fmt.Sprintf("/{%s}/delete", UUIDKey),
-		Service:      &DeletingService{s},
-		RequiresAuth: true,
-		AuthTokens:   conf.Devices,
-	})
-
-	// set up enabling endpoint
-	httpServer.AddEndpoint(ServerEndpoint{
-		Path:         fmt.Sprintf("/{%s}/enable", UUIDKey),
-		Service:      &EnablingService{s},
-		RequiresAuth: true,
-		AuthTokens:   conf.Devices,
-	})
-
-	// set up disabling endpoint
-	httpServer.AddEndpoint(ServerEndpoint{
-		Path:         fmt.Sprintf("/{%s}/disable", UUIDKey),
-		Service:      &DisablingService{s},
+		Path:         fmt.Sprintf("/{%s}/{%s}", UUIDKey, OperationKey),
+		Service:      &HashOperationsService{s},
 		RequiresAuth: true,
 		AuthTokens:   conf.Devices,
 	})

--- a/main/main.go
+++ b/main/main.go
@@ -108,7 +108,7 @@ func main() {
 		protocol:       &p,
 		env:            conf.Env,
 		authServiceURL: conf.Niomon,
-		MessageHandler: make(chan HTTPMessage, 100),
+		MessageHandler: make(chan HTTPRequest, 100),
 	}
 
 	g.Go(func() error {

--- a/main/main.go
+++ b/main/main.go
@@ -117,11 +117,34 @@ func main() {
 
 	// set up anchoring endpoint
 	httpServer.AddEndpoint(ServerEndpoint{
-		Path: fmt.Sprintf("/{%s}", UUIDKey),
-		Service: &AnchoringService{
-			Signer:     s,
-			AuthTokens: conf.Devices,
-		},
+		Path:         fmt.Sprintf("/{%s}", UUIDKey),
+		Service:      &AnchoringService{s},
+		RequiresAuth: true,
+		AuthTokens:   conf.Devices,
+	})
+
+	// set up deleting endpoint
+	httpServer.AddEndpoint(ServerEndpoint{
+		Path:         fmt.Sprintf("/{%s}/delete", UUIDKey),
+		Service:      &DeletingService{s},
+		RequiresAuth: true,
+		AuthTokens:   conf.Devices,
+	})
+
+	// set up enabling endpoint
+	httpServer.AddEndpoint(ServerEndpoint{
+		Path:         fmt.Sprintf("/{%s}/enable", UUIDKey),
+		Service:      &EnablingService{s},
+		RequiresAuth: true,
+		AuthTokens:   conf.Devices,
+	})
+
+	// set up disabling endpoint
+	httpServer.AddEndpoint(ServerEndpoint{
+		Path:         fmt.Sprintf("/{%s}/disable", UUIDKey),
+		Service:      &DisablingService{s},
+		RequiresAuth: true,
+		AuthTokens:   conf.Devices,
 	})
 
 	// set up verification endpoint
@@ -133,10 +156,8 @@ func main() {
 	}
 
 	httpServer.AddEndpoint(ServerEndpoint{
-		Path: "/verify",
-		Service: &VerificationService{
-			Verifier: v,
-		},
+		Path:    "/verify",
+		Service: &VerificationService{v},
 	})
 
 	// start HTTP server

--- a/main/main.go
+++ b/main/main.go
@@ -120,7 +120,7 @@ func main() {
 	httpServer.AddEndpoint(ServerEndpoint{
 		Path: fmt.Sprintf("/{%s}", UUIDKey),
 		Service: &AnchoringService{
-			Signer:     s,
+			Signer:     &s,
 			AuthTokens: conf.Devices,
 		},
 	})
@@ -129,7 +129,7 @@ func main() {
 	httpServer.AddEndpoint(ServerEndpoint{
 		Path: fmt.Sprintf("/{%s}/{%s}", UUIDKey, OperationKey),
 		Service: &UpdateOperationService{
-			Signer:     s,
+			Signer:     &s,
 			AuthTokens: conf.Devices,
 		},
 	})
@@ -138,7 +138,7 @@ func main() {
 	httpServer.AddEndpoint(ServerEndpoint{
 		Path: "/verify",
 		Service: &VerificationService{
-			Verifier{
+			Verifier: &Verifier{
 				protocol:                      &p,
 				verifyServiceURL:              conf.VerifyService,
 				keyServiceURL:                 conf.KeyService,

--- a/main/main.go
+++ b/main/main.go
@@ -117,18 +117,14 @@ func main() {
 
 	// set up anchoring endpoint
 	httpServer.AddEndpoint(ServerEndpoint{
-		Path:         fmt.Sprintf("/{%s}", UUIDKey),
-		Service:      &AnchoringService{s},
-		RequiresAuth: true,
-		AuthTokens:   conf.Devices,
+		Path:    fmt.Sprintf("/{%s}", UUIDKey),
+		Service: &AnchoringService{Signer: s, AuthTokens: conf.Devices},
 	})
 
 	// set up endpoint for hash operations
 	httpServer.AddEndpoint(ServerEndpoint{
-		Path:         fmt.Sprintf("/{%s}/{%s}", UUIDKey, OperationKey),
-		Service:      &HashOperationsService{s},
-		RequiresAuth: true,
-		AuthTokens:   conf.Devices,
+		Path:    fmt.Sprintf("/{%s}/{%s}", UUIDKey, OperationKey),
+		Service: &UpdateOperationService{Signer: s, AuthTokens: conf.Devices},
 	})
 
 	// set up verification endpoint

--- a/main/signer.go
+++ b/main/signer.go
@@ -69,8 +69,6 @@ func signer(ctx context.Context, s *Signer) error {
 			resp := s.handleSigningRequest(msg)
 			msg.Response <- resp
 			if httpFailed(resp.StatusCode) {
-				log.Errorf("%s: %s", msg.ID, string(resp.Content))
-
 				// reset previous signature in protocol context to ensure intact chain
 				s.protocol.Signatures[msg.ID] = prevSign
 			} else {
@@ -109,7 +107,7 @@ func (s *Signer) handleSigningRequest(msg HTTPMessage) HTTPResponse {
 	case disableHash:
 		upp, err = s.disableHash(name, hash)
 	default:
-		err = fmt.Errorf("unsupported operation: 0x%02x", msg.Operation)
+		err = fmt.Errorf("unsupported operation: %s", msg.Operation)
 	}
 
 	if err != nil {

--- a/main/signer.go
+++ b/main/signer.go
@@ -52,7 +52,7 @@ type Signer struct {
 	protocol       *ExtendedProtocol
 	env            string
 	authServiceURL string
-	MessageHandler chan HTTPMessage
+	MessageHandler chan HTTPRequest
 }
 
 // handle incoming messages, create, sign and send a ubirch protocol packet (UPP) to the ubirch backend
@@ -88,7 +88,7 @@ func signer(ctx context.Context, s *Signer) error {
 	}
 }
 
-func (s *Signer) handleSigningRequest(msg HTTPMessage) HTTPResponse {
+func (s *Signer) handleSigningRequest(msg HTTPRequest) HTTPResponse {
 	name := msg.ID.String()
 	hash := msg.Hash[:]
 	auth := msg.Auth
@@ -197,7 +197,7 @@ func errorResponse(code int, message string) HTTPResponse {
 	}
 }
 
-func getSigningResponse(respCode int, msg HTTPMessage, upp []byte, backendResp HTTPResponse, requestID string, errMsg string) HTTPResponse {
+func getSigningResponse(respCode int, msg HTTPRequest, upp []byte, backendResp HTTPResponse, requestID string, errMsg string) HTTPResponse {
 	signingResp, err := json.Marshal(signingResponse{
 		Hash:      msg.Hash[:],
 		UPP:       upp,

--- a/main/signer.go
+++ b/main/signer.go
@@ -117,7 +117,7 @@ func (s *Signer) handleSigningRequest(msg HTTPRequest) HTTPResponse {
 	log.Debugf("%s: UPP: %s", name, hex.EncodeToString(upp))
 
 	// send UPP to ubirch backend
-	backendResp, err := post(s.authServiceURL, upp, niomonHeaders(name, auth))
+	backendResp, err := post(s.authServiceURL, upp, niomonHeader(name, auth))
 	if err != nil {
 		log.Errorf("%s: sending request to UBIRCH Authentication Service failed: %v", name, err)
 		return errorResponse(http.StatusInternalServerError, "")
@@ -165,7 +165,7 @@ func (s *Signer) deleteHash(name string, hash []byte) ([]byte, error) {
 	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Delete)
 }
 
-func niomonHeaders(name string, auth []byte) map[string]string {
+func niomonHeader(name string, auth []byte) map[string]string {
 	return map[string]string{
 		"x-ubirch-hardware-id": name,
 		"x-ubirch-auth-type":   "ubirch",
@@ -192,7 +192,7 @@ func errorResponse(code int, message string) HTTPResponse {
 	log.Error(message)
 	return HTTPResponse{
 		StatusCode: code,
-		Headers:    http.Header{"Content-Type": {"text/plain; charset=utf-8"}},
+		Header:     http.Header{"Content-Type": {"text/plain; charset=utf-8"}},
 		Content:    []byte(message),
 	}
 }
@@ -216,7 +216,7 @@ func getSigningResponse(respCode int, msg HTTPRequest, upp []byte, backendResp H
 
 	return HTTPResponse{
 		StatusCode: respCode,
-		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Header:     http.Header{"Content-Type": {"application/json"}},
 		Content:    signingResp,
 	}
 }

--- a/main/signer.go
+++ b/main/signer.go
@@ -32,9 +32,9 @@ type operation string
 
 const (
 	anchorHash  operation = "anchor"
-	deleteHash  operation = "delete"
-	enableHash  operation = "enable"
 	disableHash operation = "disable"
+	enableHash  operation = "enable"
+	deleteHash  operation = "delete"
 
 	lenRequestID = 16
 )
@@ -100,12 +100,12 @@ func (s *Signer) handleSigningRequest(msg HTTPRequest) HTTPResponse {
 	switch msg.Operation {
 	case anchorHash:
 		upp, err = s.anchorHash(name, hash)
-	case deleteHash:
-		upp, err = s.deleteHash(name, hash)
-	case enableHash:
-		upp, err = s.enableHash(name, hash)
 	case disableHash:
 		upp, err = s.disableHash(name, hash)
+	case enableHash:
+		upp, err = s.enableHash(name, hash)
+	case deleteHash:
+		upp, err = s.deleteHash(name, hash)
 	default:
 		err = fmt.Errorf("unsupported operation: \"%s\"", msg.Operation)
 	}
@@ -147,10 +147,10 @@ func (s *Signer) anchorHash(name string, hash []byte) ([]byte, error) {
 	return s.protocol.SignHash(name, hash, ubirch.Chained)
 }
 
-func (s *Signer) deleteHash(name string, hash []byte) ([]byte, error) {
-	log.Infof("%s: deleting hash: %s", name, base64.StdEncoding.EncodeToString(hash))
+func (s *Signer) disableHash(name string, hash []byte) ([]byte, error) {
+	log.Infof("%s: disabling hash: %s", name, base64.StdEncoding.EncodeToString(hash))
 
-	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Delete)
+	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Disable)
 }
 
 func (s *Signer) enableHash(name string, hash []byte) ([]byte, error) {
@@ -159,10 +159,10 @@ func (s *Signer) enableHash(name string, hash []byte) ([]byte, error) {
 	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Enable)
 }
 
-func (s *Signer) disableHash(name string, hash []byte) ([]byte, error) {
-	log.Infof("%s: disabling hash: %s", name, base64.StdEncoding.EncodeToString(hash))
+func (s *Signer) deleteHash(name string, hash []byte) ([]byte, error) {
+	log.Infof("%s: deleting hash: %s", name, base64.StdEncoding.EncodeToString(hash))
 
-	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Disable)
+	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Delete)
 }
 
 func niomonHeaders(name string, auth []byte) map[string]string {

--- a/main/signer.go
+++ b/main/signer.go
@@ -107,11 +107,11 @@ func (s *Signer) handleSigningRequest(msg HTTPRequest) HTTPResponse {
 	case disableHash:
 		upp, err = s.disableHash(name, hash)
 	default:
-		err = fmt.Errorf("unsupported operation: %s", msg.Operation)
+		err = fmt.Errorf("unsupported operation: \"%s\"", msg.Operation)
 	}
 
 	if err != nil {
-		log.Errorf("%s: %s", name, fmt.Errorf("could not create UBIRCH Protocol Package: %v", err))
+		log.Errorf("%s: could not create UBIRCH Protocol Package: %v", name, err)
 		return errorResponse(http.StatusInternalServerError, "")
 	}
 	log.Debugf("%s: UPP: %s", name, hex.EncodeToString(upp))
@@ -119,7 +119,7 @@ func (s *Signer) handleSigningRequest(msg HTTPRequest) HTTPResponse {
 	// send UPP to ubirch backend
 	backendResp, err := post(s.authServiceURL, upp, niomonHeaders(name, auth))
 	if err != nil {
-		log.Errorf("%s: %s", name, fmt.Errorf("sending request to UBIRCH Authentication Service failed: %v", err))
+		log.Errorf("%s: sending request to UBIRCH Authentication Service failed: %v", name, err)
 		return errorResponse(http.StatusInternalServerError, "")
 	}
 	log.Debugf("%s: backend response: (%d) %s", name, backendResp.StatusCode, hex.EncodeToString(backendResp.Content))

--- a/main/signer.go
+++ b/main/signer.go
@@ -75,7 +75,6 @@ func signer(ctx context.Context, s *Signer) error {
 				// persist last signature after UPP was successfully received in ubirch backend
 				err := s.protocol.PersistContext()
 				if err != nil {
-					msg.Response <- errorResponse(http.StatusInternalServerError, "")
 					return fmt.Errorf("unable to persist last signature: %v [\"%s\": \"%s\"]",
 						err, msg.ID.String(), base64.StdEncoding.EncodeToString(s.protocol.Signatures[msg.ID]))
 				}

--- a/main/signer.go
+++ b/main/signer.go
@@ -81,7 +81,7 @@ func signer(ctx context.Context, s *Signer) error {
 			}
 
 		case <-ctx.Done():
-			log.Println("finishing signer")
+			log.Debug("shutting down signer")
 			return nil
 		}
 	}

--- a/main/signer.go
+++ b/main/signer.go
@@ -116,7 +116,7 @@ func (s *Signer) handleSigningRequest(msg HTTPRequest) HTTPResponse {
 	log.Debugf("%s: UPP: %s", name, hex.EncodeToString(upp))
 
 	// send UPP to ubirch backend
-	backendResp, err := post(s.authServiceURL, upp, niomonHeader(name, auth))
+	backendResp, err := post(s.authServiceURL, upp, ubirchHeader(msg.ID, auth))
 	if err != nil {
 		log.Errorf("%s: sending request to UBIRCH Authentication Service failed: %v", name, err)
 		return errorResponse(http.StatusInternalServerError, "")
@@ -162,14 +162,6 @@ func (s *Signer) deleteHash(name string, hash []byte) ([]byte, error) {
 	log.Infof("%s: deleting hash: %s", name, base64.StdEncoding.EncodeToString(hash))
 
 	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Delete)
-}
-
-func niomonHeader(name string, auth []byte) map[string]string {
-	return map[string]string{
-		"x-ubirch-hardware-id": name,
-		"x-ubirch-auth-type":   "ubirch",
-		"x-ubirch-credential":  base64.StdEncoding.EncodeToString(auth),
-	}
 }
 
 func getRequestID(respUPP ubirch.UPP) (string, error) {

--- a/main/signer.go
+++ b/main/signer.go
@@ -53,7 +53,6 @@ type Signer struct {
 	env            string
 	authServiceURL string
 	MessageHandler chan HTTPMessage
-	AuthTokens     map[string]string
 }
 
 // handle incoming messages, create, sign and send a ubirch protocol packet (UPP) to the ubirch backend

--- a/main/signer.go
+++ b/main/signer.go
@@ -28,88 +28,147 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const lenRequestID = 16
+
+type signingResponse struct {
+	Error     string       `json:"error,omitempty"`
+	Hash      []byte       `json:"hash,omitempty"`
+	UPP       []byte       `json:"upp,omitempty"`
+	Response  HTTPResponse `json:"response,omitempty"`
+	RequestID string       `json:"requestID,omitempty"`
+}
+
+type Signer struct {
+	protocol       *ExtendedProtocol
+	env            string
+	authServiceURL string
+	MessageHandler chan HTTPMessage
+	AuthTokens     map[string]string
+}
+
 // handle incoming messages, create, sign and send a ubirch protocol packet (UPP) to the ubirch backend
-func signer(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtocol, conf Config) error {
+func signer(ctx context.Context, s *Signer) error {
 	for {
 		select {
-		case msg := <-msgHandler:
-			uid := msg.ID
-			name := uid.String()
-
-			// create a chained UPP
-			log.Printf("%s: signing hash: %s", name, base64.StdEncoding.EncodeToString(msg.Hash[:]))
-
-			upp, err := p.SignHash(name, msg.Hash[:], ubirch.Chained)
-			if err != nil {
-				msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error creating UPP for UUID %s: %v", name, err))
-				continue
+		case msg := <-s.MessageHandler:
+			// buffer last previous signature to be able to reset it in case sending UPP to backend fails
+			prevSign, found := s.protocol.Signatures[msg.ID]
+			if !found {
+				prevSign = make([]byte, 64)
 			}
-			log.Debugf("%s: UPP: %s", name, hex.EncodeToString(upp))
 
-			// send UPP to ubirch backend
-			respCode, respBody, respHeaders, err := post(conf.Niomon, upp, map[string]string{
-				"x-ubirch-hardware-id": name,
-				"x-ubirch-auth-type":   "ubirch",
-				"x-ubirch-credential":  base64.StdEncoding.EncodeToString(msg.Auth),
-			})
-			if err != nil {
-				msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, fmt.Sprintf("error sending UPP to backend: %v", err))
-				continue
-			}
-			log.Debugf("%s: response: (%d) %s", name, respCode, hex.EncodeToString(respBody))
+			resp := s.handleSigningRequest(msg)
+			msg.Response <- resp
+			if httpFailed(resp.Code) {
+				log.Errorf("%s: %s", msg.ID, string(resp.Content))
 
-			var requestID uuid.UUID
-
-			// decode the backend response
-			respUPP, err := ubirch.Decode(respBody)
-			if err != nil {
-				log.Warnf("unable to decode backend response: %v\n backend response was: (%d) %q",
-					err, respCode, respBody)
+				// reset previous signature in protocol context to ensure intact chain
+				s.protocol.Signatures[msg.ID] = prevSign
 			} else {
-
-				// todo verify backend response signature
-
-				// get request ID from backend response payload
-				requestID, err = uuid.FromBytes(respUPP.GetPayload()[:16])
+				// persist last signature after UPP was successfully received in ubirch backend
+				err := s.protocol.PersistContext()
 				if err != nil {
-					log.Warnf("unable to get request ID from backend response payload: %v\n backend response payload was: %q",
-						err, respUPP.GetPayload())
+					msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, "")
+					return fmt.Errorf("unable to persist last signature: %v [\"%s\": \"%s\"]",
+						err, msg.ID.String(), base64.StdEncoding.EncodeToString(s.protocol.Signatures[msg.ID]))
 				}
 			}
-
-			// check if sending was successful
-			if httpFailed(respCode) {
-				log.Errorf("%s: sending UPP to %s failed: (%d) %q", name, conf.Niomon, respCode, respBody)
-				// reset last signature in protocol context if sending UPP to backend fails to ensure intact chain
-				err = p.LoadContext()
-			} else {
-				log.Infof("%s: UPP sent to %s (request ID: %s)", name, conf.Niomon, requestID)
-				// save last signature after UPP was successfully received in ubirch backend
-				err = p.PersistContext()
-			}
-			if err != nil {
-				msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, "")
-				return fmt.Errorf("unable to load/persist last signature for UUID %s: %v", name, err)
-			}
-
-			response, err := json.Marshal(map[string][]byte{
-				"hash":      msg.Hash[:],
-				"upp":       upp,
-				"requestID": requestID[:],
-				"response":  respBody,
-			})
-			if err != nil {
-				log.Warnf("error serializing extended response: %v", err)
-				response = respBody
-			} else {
-				respHeaders.Del("Content-Length")
-				respHeaders.Set("Content-Type", "application/json")
-			}
-			msg.Response <- HTTPResponse{Code: respCode, Headers: respHeaders, Content: response}
 
 		case <-ctx.Done():
 			log.Println("finishing signer")
 			return nil
 		}
+	}
+}
+
+func (s *Signer) handleSigningRequest(msg HTTPMessage) HTTPResponse {
+	name := msg.ID.String()
+	hash := msg.Hash[:]
+	auth := msg.Auth
+
+	// create and sign a UPP containing the hash
+	upp, err := s.anchorHash(name, hash)
+	if err != nil {
+		log.Errorf("%s: %s", name, fmt.Errorf("could not create UBIRCH Protocol Package: %v", err))
+		return HTTPErrorResponse(http.StatusInternalServerError, "")
+	}
+	log.Debugf("%s: UPP: %s", name, hex.EncodeToString(upp))
+
+	// send UPP to ubirch backend
+	backendResp, err := post(s.authServiceURL, upp, niomonHeaders(name, auth))
+	if err != nil {
+		log.Errorf("%s: %s", name, fmt.Errorf("sending request to UBIRCH Authentication Service failed: %v", err))
+		return HTTPErrorResponse(http.StatusInternalServerError, "")
+	}
+	log.Debugf("%s: backend response: (%d) %s", name, backendResp.Code, hex.EncodeToString(backendResp.Content))
+
+	// decode the backend response UPP and get request ID
+	var requestID string
+	responseUPPStruct, err := ubirch.Decode(backendResp.Content)
+	if err != nil {
+		log.Warnf("decoding backend response failed: %v, backend response: (%d) %q", err, backendResp.Code, backendResp.Content)
+	} else {
+		requestID, err = getRequestID(responseUPPStruct)
+		if err != nil {
+			log.Warnf("could not get request ID from backend response: %v", err)
+		} else {
+			log.Infof("%s: request ID: %s", name, requestID)
+		}
+	}
+
+	return getSigningResponse(backendResp.Code, hash, upp, backendResp, requestID, "")
+}
+
+func (s *Signer) anchorHash(name string, hash []byte) ([]byte, error) {
+	log.Infof("%s: anchoring hash: %s", name, base64.StdEncoding.EncodeToString(hash))
+
+	return s.protocol.SignHash(name, hash, ubirch.Chained)
+}
+
+func niomonHeaders(name string, auth []byte) map[string]string {
+	return map[string]string{
+		"x-ubirch-hardware-id": name,
+		"x-ubirch-auth-type":   "ubirch",
+		"x-ubirch-credential":  base64.StdEncoding.EncodeToString(auth),
+	}
+}
+
+func getRequestID(respUPP ubirch.UPP) (string, error) {
+	respPayload := respUPP.GetPayload()
+	if len(respPayload) < lenRequestID {
+		return "n/a", fmt.Errorf("response payload does not contain request ID: %q", respPayload)
+	}
+	requestID, err := uuid.FromBytes(respPayload[:lenRequestID])
+	if err != nil {
+		return "n/a", err
+	}
+	return requestID.String(), nil
+}
+
+func getSigningResponse(respCode int, hash []byte, uppBytes []byte, backendResp HTTPResponse, requestID string, errMsg string) HTTPResponse {
+	uppStruct, err := ubirch.Decode(uppBytes)
+	if err != nil {
+		log.Warnf("error decoding UPP: %v", err)
+	}
+
+	signingResp, err := json.Marshal(signingResponse{
+		Hash:      hash,
+		UPP:       uppBytes,
+		Response:  backendResp,
+		RequestID: requestID,
+		Error:     errMsg,
+	})
+	if err != nil {
+		log.Warnf("error serializing signing response: %v", err)
+	}
+
+	if httpFailed(respCode) {
+		log.Errorf("%s: %s", uppStruct.GetUuid(), string(signingResp))
+	}
+
+	return HTTPResponse{
+		Code:    respCode,
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Content: signingResp,
 	}
 }

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -205,8 +205,8 @@ func getVerificationResponse(respCode int, hash []byte, uppBytes []byte, name st
 	}
 
 	return HTTPResponse{
-		Code:    respCode,
-		Headers: http.Header{"Content-Type": {"application/json"}},
-		Content: verificationResp,
+		StatusCode: respCode,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Content:    verificationResp,
 	}
 }

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -92,7 +92,7 @@ func verifyUPP(p *ExtendedProtocol, upp []byte, keyService string) (uuid.UUID, e
 	}
 	log.Debugf("verifying validity of UPP signature using pubkey %s of identity %s", base64.StdEncoding.EncodeToString(pubkey), name)
 
-	verified, err := p.Verify(name, upp, ubirch.Chained)
+	verified, err := p.Verify(name, upp)
 	if err != nil {
 		return id, err
 	}

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -17,11 +17,11 @@
 package main
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -38,10 +38,47 @@ type verification struct {
 	Anchors []byte `json:"anchors"`
 }
 
+type verificationResponse struct {
+	Error  string `json:"error,omitempty"`
+	Hash   []byte `json:"hash,omitempty"`
+	UPP    []byte `json:"upp,omitempty"`
+	UUID   string `json:"uuid,omitempty"`
+	PubKey []byte `json:"pubKey,omitempty"`
+}
+
+type Verifier struct {
+	protocol                      *ExtendedProtocol
+	verifyServiceURL              string
+	keyServiceURL                 string
+	verifyFromKnownIdentitiesOnly bool
+}
+
+func (v *Verifier) verifyHash(hash []byte) HTTPResponse {
+	log.Infof("verifying hash %s", base64.StdEncoding.EncodeToString(hash))
+
+	// retrieve certificate for hash from the ubirch backend
+	code, upp, err := v.loadUPP(hash)
+	if err != nil {
+		log.Error(err)
+		return HTTPErrorResponse(code, err.Error())
+	}
+	log.Debugf("retrieved UPP %s", hex.EncodeToString(upp))
+
+	// verify validity of the retrieved UPP locally
+	name, pkey, err := v.verifyUPP(upp)
+	if err != nil {
+		return getVerificationResponse(http.StatusUnprocessableEntity, hash, upp, name, pkey, err.Error())
+	}
+	log.Debugf("verified UPP from identity %s using public key %s", name, base64.StdEncoding.EncodeToString(pkey))
+
+	return getVerificationResponse(http.StatusOK, hash, upp, name, pkey, "")
+}
+
 // loadUPP retrieves the UPP which contains a given hash from the ubirch backend
-func loadUPP(hashString string, verifyService string) ([]byte, int, error) {
+func (v *Verifier) loadUPP(hash []byte) (int, []byte, error) {
 	var resp *http.Response
 	var err error
+	hashBase64String := base64.StdEncoding.EncodeToString(hash)
 
 	n := 0
 	for stay, timeout := true, time.After(5*time.Second); stay; {
@@ -50,14 +87,14 @@ func loadUPP(hashString string, verifyService string) ([]byte, int, error) {
 		case <-timeout:
 			stay = false
 		default:
-			resp, err = http.Post(verifyService, "text/plain", strings.NewReader(hashString))
+			resp, err = http.Post(v.verifyServiceURL, "text/plain", strings.NewReader(hashBase64String))
 			if err != nil {
-				return nil, http.StatusInternalServerError, fmt.Errorf("error sending verification request: %v", err)
+				return http.StatusInternalServerError, nil, fmt.Errorf("error sending verification request: %v", err)
 			}
 			stay = httpFailed(resp.StatusCode)
 			if stay {
 				_ = resp.Body.Close()
-				log.Printf("Couldn't verify hash yet (%d). Retry... %d", resp.StatusCode, n)
+				log.Debugf("Couldn't verify hash yet (%d). Retry... %d", resp.StatusCode, n)
 				time.Sleep(time.Second)
 			}
 		}
@@ -66,119 +103,110 @@ func loadUPP(hashString string, verifyService string) ([]byte, int, error) {
 	defer resp.Body.Close()
 
 	if httpFailed(resp.StatusCode) {
-		return nil, resp.StatusCode, fmt.Errorf("could not (yet) retrieve certificate for hash %s from verification service (%s): %s", hashString, verifyService, resp.Status)
+		respBodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Warnf("unable to decode verification response: %v", err)
+		}
+		return resp.StatusCode, nil, fmt.Errorf("could not retrieve certificate for hash %s from UBIRCH verification service (%s): - %s - %q", hashBase64String, v.verifyServiceURL, resp.Status, respBodyBytes)
 	}
 
 	vf := verification{}
 	err = json.NewDecoder(resp.Body).Decode(&vf)
 	if err != nil {
-		return nil, http.StatusInternalServerError, fmt.Errorf("unable to decode verification response: %v", err)
+		return http.StatusBadGateway, nil, fmt.Errorf("unable to decode verification response: %v", err)
 	}
-	return vf.UPP, resp.StatusCode, nil
+	return resp.StatusCode, vf.UPP, nil
 }
 
-// verifyUPP verifies the validity of a UPP's signature. Requests public key from the key service if unknown.
-func verifyUPP(p *ExtendedProtocol, upp []byte, keyService string) (uuid.UUID, error) {
-	o, err := ubirch.DecodeChained(upp)
+// verifyUPP verifies the signature of UPPs from known identities using their public keys from the local keystore
+func (v *Verifier) verifyUPP(upp []byte) (string, []byte, error) {
+	uppStruct, err := ubirch.Decode(upp)
 	if err != nil {
-		return uuid.Nil, fmt.Errorf("UPP decoding failed: %v", err)
+		return "", nil, fmt.Errorf("retrieved invalid UPP: %v", err)
 	}
-	id := o.Uuid
+
+	id := uppStruct.GetUuid()
 	name := id.String()
 
-	pubkey, err := loadPublicKey(p, name, id, keyService)
+	pubkey, err := v.protocol.GetPublicKey(name)
 	if err != nil {
-		return id, err
+		if v.verifyFromKnownIdentitiesOnly {
+			return name, nil, fmt.Errorf("retrieved certificate for requested hash is from unknown identity")
+		} else {
+			log.Warnf("couldn't get public key for identity %s from local context", name)
+			pubkey, err = v.loadPublicKey(name, id)
+			if err != nil {
+				return name, nil, err
+			}
+		}
 	}
-	log.Debugf("verifying validity of UPP signature using pubkey %s of identity %s", base64.StdEncoding.EncodeToString(pubkey), name)
 
-	verified, err := p.Verify(name, upp)
-	if err != nil {
-		return id, err
-	}
+	verified, err := v.protocol.Verify(name, upp)
 	if !verified {
-		return id, fmt.Errorf("validity of UPP signature could not be verified using public key %s of identity %s", base64.StdEncoding.EncodeToString(pubkey), name)
+		if err != nil {
+			log.Error(err)
+		}
+		return name, pubkey, fmt.Errorf("signature of retrieved certificate for requested hash could not be verified")
 	}
-	return id, nil
+
+	return name, pubkey, nil
 }
 
 // loadPublicKey retrieves the first valid public key associated with an identity from the key service
-func loadPublicKey(p *ExtendedProtocol, name string, id uuid.UUID, keyService string) ([]byte, error) {
-	pubkey, err := p.GetPublicKey(name)
+func (v *Verifier) loadPublicKey(name string, id uuid.UUID) ([]byte, error) {
+	log.Debugf("requesting public key for identity %s from key service (%s)", id.String(), v.keyServiceURL)
+
+	keys, err := requestPublicKeys(v.keyServiceURL, id)
 	if err != nil {
-		log.Warnf("couldn't get public key for identity %s from local context", name)
-		log.Printf("requesting public key for identity %s from key service: %s", id.String(), keyService)
-
-		keys, err := requestPublicKeys(keyService, id)
-		if err != nil {
-			return nil, err
-		}
-
-		if len(keys) < 1 {
-			return nil, fmt.Errorf("no public key for identity %s registered at key service (%s)", id.String(), keyService)
-		} else if len(keys) > 1 {
-			log.Warnf("several public keys registered for identity %s", id.String())
-		}
-
-		log.Printf("retrieved public key for identity %s: %s", keys[0].PubKeyInfo.HwDeviceId, keys[0].PubKeyInfo.PubKey)
-
-		pubkey, err = base64.StdEncoding.DecodeString(keys[0].PubKeyInfo.PubKey)
-		if err != nil {
-			return nil, fmt.Errorf("public key not in base64 encoding: %v", err)
-		}
-
-		err = p.SetPublicKey(name, id, pubkey)
-		if err != nil {
-			return nil, fmt.Errorf("unable to set public key in protocol context: %v", err)
-		}
-
-		// persist new public key
-		err = p.PersistContext()
-		if err != nil {
-			log.Errorf("unable to persist retrieved public key for UUID %s: %v", name, err)
-		}
+		return nil, err
 	}
+
+	if len(keys) < 1 {
+		return nil, fmt.Errorf("no public key for identity %s registered at key service (%s)", id.String(), v.keyServiceURL)
+	} else if len(keys) > 1 {
+		log.Warnf("several public keys registered for identity %s", id.String())
+	}
+
+	log.Printf("retrieved public key for identity %s: %s", keys[0].PubKeyInfo.HwDeviceId, keys[0].PubKeyInfo.PubKey)
+
+	pubkey, err := base64.StdEncoding.DecodeString(keys[0].PubKeyInfo.PubKey)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding retrieved public key: %v", err)
+	}
+
+	// inject new public key into protocol context for verification
+	err = v.protocol.SetPublicKey(name, id, pubkey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to set retrieved public key for verification: %v", err)
+	}
+
+	err = v.protocol.PersistContext()
+	if err != nil {
+		log.Errorf("unable to persist retrieved public key for UUID %s: %v", name, err)
+	}
+
 	return pubkey, nil
 }
 
-// verifier retrieves corresponding UPP for a given hash from the ubirch backend and verifies the validity of its signature
-func verifier(ctx context.Context, msgHandler chan HTTPMessage, p *ExtendedProtocol, conf Config) error {
-	for {
-		select {
-		case msg := <-msgHandler:
+func getVerificationResponse(respCode int, hash []byte, uppBytes []byte, name string, pkey []byte, errMsg string) HTTPResponse {
+	verificationResp, err := json.Marshal(verificationResponse{
+		Hash:   hash,
+		UPP:    uppBytes,
+		UUID:   name,
+		PubKey: pkey,
+		Error:  errMsg,
+	})
+	if err != nil {
+		log.Warnf("error serializing response: %v", err)
+	}
 
-			hash64 := base64.StdEncoding.EncodeToString(msg.Hash[:])
-			log.Printf("%s: verifying", hash64)
+	if httpFailed(respCode) {
+		log.Errorf("%s", string(verificationResp))
+	}
 
-			// retrieve corresponding UPP from the ubirch backend
-			upp, code, err := loadUPP(hash64, conf.VerifyService)
-			if err != nil {
-				msg.Response <- HTTPErrorResponse(code, fmt.Sprintf("verification of hash %s failed! %v", hash64, err))
-				continue
-			}
-
-			upp64 := base64.StdEncoding.EncodeToString(upp)
-			log.Debugf("%s: retrieved UPP: %s", hash64, hex.EncodeToString(upp))
-
-			// verify validity of the retrieved UPP locally
-			uid, err := verifyUPP(p, upp, conf.KeyService)
-			if err != nil {
-				msg.Response <- HTTPErrorResponse(http.StatusInternalServerError, fmt.Sprintf("verification of UPP %s failed! %v", upp64, err))
-				continue
-			}
-
-			headers := map[string][]string{"Content-Type": {"application/json"}}
-			response, err := json.Marshal(map[string]string{"uuid": uid.String(), "hash": hash64, "upp": upp64})
-			if err != nil {
-				log.Warnf("error serializing extended response: %s", err)
-				headers = map[string][]string{"Content-Type": {"application/octet-stream"}}
-				response = upp
-			}
-			msg.Response <- HTTPResponse{Code: code, Headers: headers, Content: response}
-
-		case <-ctx.Done():
-			log.Println("finishing verifier")
-			return nil
-		}
+	return HTTPResponse{
+		Code:    respCode,
+		Headers: http.Header{"Content-Type": {"application/json"}},
+		Content: verificationResp,
 	}
 }

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -60,7 +60,7 @@ func (v *Verifier) verifyHash(hash []byte) HTTPResponse {
 	code, upp, err := v.loadUPP(hash)
 	if err != nil {
 		log.Error(err)
-		return getErrorResponse(code, err.Error())
+		return errorResponse(code, err.Error())
 	}
 	log.Debugf("retrieved UPP %s", hex.EncodeToString(upp))
 
@@ -188,10 +188,10 @@ func (v *Verifier) loadPublicKey(name string, id uuid.UUID) ([]byte, error) {
 	return pubkey, nil
 }
 
-func getVerificationResponse(respCode int, hash []byte, uppBytes []byte, name string, pkey []byte, errMsg string) HTTPResponse {
+func getVerificationResponse(respCode int, hash []byte, upp []byte, name string, pkey []byte, errMsg string) HTTPResponse {
 	verificationResp, err := json.Marshal(verificationResponse{
 		Hash:   hash,
-		UPP:    uppBytes,
+		UPP:    upp,
 		UUID:   name,
 		PubKey: pkey,
 		Error:  errMsg,

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -59,7 +59,6 @@ func (v *Verifier) verifyHash(hash []byte) HTTPResponse {
 	// retrieve certificate for hash from the ubirch backend
 	code, upp, err := v.loadUPP(hash)
 	if err != nil {
-		log.Error(err)
 		return errorResponse(code, err.Error())
 	}
 	log.Debugf("retrieved UPP %s", hex.EncodeToString(upp))

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -60,7 +60,7 @@ func (v *Verifier) verifyHash(hash []byte) HTTPResponse {
 	code, upp, err := v.loadUPP(hash)
 	if err != nil {
 		log.Error(err)
-		return HTTPErrorResponse(code, err.Error())
+		return getErrorResponse(code, err.Error())
 	}
 	log.Debugf("retrieved UPP %s", hex.EncodeToString(upp))
 

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -205,7 +205,7 @@ func getVerificationResponse(respCode int, hash []byte, upp []byte, name string,
 
 	return HTTPResponse{
 		StatusCode: respCode,
-		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Header:     http.Header{"Content-Type": {"application/json"}},
 		Content:    verificationResp,
 	}
 }


### PR DESCRIPTION
**Added:**
- support for hash update operations: `disable`, `enable` and `delete`
- HTTP responses contain complete backend response (struct), operation and possibly error message

**Changed:**
- refactored signer and verifier and HTTP service, better maintainability 
- enhanced HTTP responses and error logging
- updated readme:
    - added info on `identities.json` file
    - reworked "How to acquire the ubirch backend token" info, removed reference to demo stage
    - removed reference to demo stage from example configs
    - added info on hash update operations (`disable`, `enable` and `delete`)
    - added description of extended HTTP responses
    - updated quick-start example