### PR TITLE
further fixes

### DIFF
--- a/load-test/go.mod
+++ b/load-test/go.mod
@@ -1,0 +1,5 @@
+module github.com/ubirch/load-test
+
+go 1.16
+
+require github.com/sirupsen/logrus v1.8.1

--- a/load-test/helper.go
+++ b/load-test/helper.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type signingResponse struct {
+	Error     string       `json:"error,omitempty"`
+	Operation string       `json:"operation,omitempty"`
+	Hash      []byte       `json:"hash,omitempty"`
+	UPP       []byte       `json:"upp,omitempty"`
+	Response  HTTPResponse `json:"response,omitempty"`
+	RequestID string       `json:"requestID,omitempty"`
+}
+
+type HTTPResponse struct {
+	StatusCode int         `json:"statusCode"`
+	Header     http.Header `json:"header"`
+	Content    []byte      `json:"content"`
+}
+
+type Config struct {
+	Devices map[string]string `json:"devices"`
+}
+
+func (c *Config) Load(filename string) error {
+	fileHandle, err := os.Open(filename)
+	if err != nil {
+		return err
+	}
+	defer fileHandle.Close()
+
+	return json.NewDecoder(fileHandle).Decode(c)
+}
+
+func getTestIdentities(num int) map[string]string {
+	c := Config{}
+	err := c.Load(configFile)
+	if err != nil {
+		log.Fatalf("ERROR: unable to load configuration: %s", err)
+	}
+
+	testIdentities := make(map[string]string, num)
+
+	for uid, auth := range c.Devices {
+		testIdentities[uid] = auth
+		if len(testIdentities) == num {
+			break
+		}
+	}
+
+	return testIdentities
+}
+
+func setup() {
+	log.SetFormatter(&log.TextFormatter{FullTimestamp: true, TimestampFormat: "2006-01-02 15:04:05.000 -0700"})
+	log.SetLevel(log.DebugLevel)
+}

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	clientBaseURL         = "http://localhost:8080/"
+	configFile            = "../main/config.json"
+	numberOfTestIDs       = 100
+	numberOfRequestsPerID = 50
+)
+
+func main() {
+	setup()
+	var wg sync.WaitGroup
+
+	testIdentities := getTestIdentities(numberOfTestIDs)
+
+	for uid, auth := range testIdentities {
+		sendRequests(uid, auth, &wg)
+	}
+
+	log.Debug("waiting...")
+	wg.Wait()
+	log.Info("done")
+}
+
+func sendRequests(id string, auth string, wg *sync.WaitGroup) {
+	HTTPclient := &http.Client{Timeout: 65 * time.Second}
+	clientURL := clientBaseURL + id + "/hash"
+	header := http.Header{}
+	header.Set("Content-Type", "application/octet-stream")
+	header.Set("X-Auth-Token", auth)
+
+	for i := 1; i <= numberOfRequestsPerID; i++ {
+		wg.Add(1)
+		go sendAndCheckResponse(HTTPclient, clientURL, header, wg)
+	}
+}
+
+func sendAndCheckResponse(HTTPclient *http.Client, clientURL string, header http.Header, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	hash := make([]byte, 32)
+	_, err := rand.Read(hash)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	resp, err := sendRequest(HTTPclient, clientURL, header, hash)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	// check resp -> hash
+	if !bytes.Equal(hash, resp.Hash) {
+		log.Error("HASH MISMATCH")
+	}
+	// todo check resp -> chain
+}
+
+func sendRequest(HTTPclient *http.Client, clientURL string, header http.Header, hash []byte) (signingResponse, error) {
+	req, err := http.NewRequest(http.MethodPost, clientURL, bytes.NewBuffer(hash))
+	if err != nil {
+		return signingResponse{}, err
+	}
+
+	req.Header = header
+
+	resp, err := HTTPclient.Do(req)
+	if err != nil {
+		return signingResponse{}, err
+	}
+
+	//noinspection GoUnhandledErrorResult
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return signingResponse{}, fmt.Errorf(resp.Status)
+	}
+
+	clientResponse := signingResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&clientResponse)
+	if err != nil {
+		return signingResponse{}, err
+	}
+
+	return clientResponse, nil
+}

--- a/main/main.go
+++ b/main/main.go
@@ -108,7 +108,7 @@ func main() {
 		protocol:       &p,
 		env:            conf.Env,
 		authServiceURL: conf.Niomon,
-		MessageHandler: make(chan HTTPRequest, 200), // 4rps * 50s => space for 200 requests
+		MessageHandler: make(chan HTTPRequest, 150), // 3rps * 50s
 	}
 
 	// start synchronous chaining routine

--- a/main/main.go
+++ b/main/main.go
@@ -108,7 +108,7 @@ func main() {
 		protocol:       &p,
 		env:            conf.Env,
 		authServiceURL: conf.Niomon,
-		MessageHandler: make(chan HTTPRequest, 150), // 3rps * 50s
+		MessageHandler: make(chan HTTPRequest, 150), // 3rps * 50s // TODO: make configurable
 	}
 
 	// start synchronous chaining routine
@@ -142,7 +142,7 @@ func main() {
 				protocol:                      &p,
 				verifyServiceURL:              conf.VerifyService,
 				keyServiceURL:                 conf.KeyService,
-				verifyFromKnownIdentitiesOnly: false, // todo add to config
+				verifyFromKnownIdentitiesOnly: false, // TODO: make configurable
 			},
 		},
 	})

--- a/main/signer.go
+++ b/main/signer.go
@@ -78,7 +78,6 @@ func (s *Signer) chainer() error {
 		}
 
 		resp := s.handleSigningRequest(msg)
-
 		msg.respond(resp)
 
 		if httpFailed(resp.StatusCode) {

--- a/main/signer.go
+++ b/main/signer.go
@@ -65,6 +65,12 @@ func (msg HTTPRequest) respond(resp HTTPResponse) {
 // handle incoming messages, create, sign and send a ubirch protocol packet (UPP) to the ubirch backend
 func (s *Signer) chainer() error {
 	for msg := range s.MessageHandler {
+		// the message might have waited in the channel for a while
+		// check if the context is expired or canceled by now
+		if msg.RequestCtx.Err() != nil {
+			continue
+		}
+
 		// buffer last previous signature to be able to reset it in case sending UPP to backend fails
 		prevSign, found := s.protocol.Signatures[msg.ID]
 		if !found {


### PR DESCRIPTION
**Changed:**

- optimized request buffer size after load test

> _We currently seem to have an avg. throughput of just over 3rps. If a request will time out after 55s, the buffer should have a capacity of 150._

**Fixed:**

- do not block if trying to send response when receiver is already gone
- check before chaining if request context has already been canceled

**Added:**

- basic load test