### PR TITLE
UNG-1760 refactor protocol context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOVERSION=1.15
+ARG GOVERSION=1.16
 FROM golang:$GOVERSION-alpine AS builder
 COPY . /app
 ARG GOARCH=amd64

--- a/README.md
+++ b/README.md
@@ -19,9 +19,12 @@ a restart.
 ---
 **WARNING**
 
-Per default, the client creates a file `protocol.json` in the working directory, where it stores the encrypted signing
-keys and last signatures for chaining. **Do not delete this file** as our backend will not accept new key registrations
-once a device already has a registered key.
+By default, the client stores the encrypted signing keys in a local file `keys.json`, which will be created in the
+working directory upon start-up. **Do not delete this file**, as our backend will not accept new key registrations once
+a device already has a registered key.
+
+Further, the client creates a subdirectory `/signatures` with multiple binary files, which contain the previous UPP
+signatures for chaining.
 
 ---
 
@@ -40,8 +43,8 @@ Docker Hub Address: [ubirch/ubirch-client](https://hub.docker.com/r/ubirch/ubirc
 - System based on Intel/AMD64 or ARM
 - Docker installation
 - Space to store last used signatures and key material, either:
-  - disk space, mounted into the docker pod, or
-  - as SQL database
+    - disk space, mounted into the docker pod, or
+    - as SQL database
 - Possibility to send a HTTP request to UBIRCH.com domains
 - A unique identifier (UUID) registered with the UBIRCH console
 - A corresponding authentication token (acquired via UBIRCH console)
@@ -149,7 +152,7 @@ To switch to the `demo` backend environment
 
 The `DSN` (*Data Source Name*) can be used to connect the client to a SQL database for storing the protocol context
 (i.e. the encrypted keystore and last signatures) persistently. If DSN is not set or empty, the client will create a
-file `protocol.json` (and `protocol.json.bck`) locally in the working directory.
+file `keys.json` (and `keys.json.bck`) as well as a subdirectory `/signatures` locally in the working directory.
 
 If you want to use a SQL database instead of a local file, make sure to apply the
 [database schema](main/schema.sql), as the application will not create it itself on first run, and set the DSN in the
@@ -610,8 +613,8 @@ and insignificant space characters were elided.
     {"level":"info","msg":"UBIRCH client (v2.0.0, build=local)","time":"2021-03-01T18:41:20+01:00"}
     {"level":"info","msg":"loading configuration from file: config.json","time":"2021-03-01T18:41:20+01:00"}
     INFO[2021-03-01 18:41:20.291 +0100] 1 known UUID(s)
-    INFO[2021-03-01 18:41:20.291 +0100] UBIRCH backend "prod" environment
-    INFO[2021-03-01 18:41:20.291 +0100] protocol context will be saved to file: protocol.json
+    INFO[2021-03-01 18:41:20.291 +0100] UBIRCH backend environment: prod
+    INFO[2021-03-01 18:41:20.291 +0100] protocol context will be stored in local file system
     INFO[2021-03-01 18:41:20.291 +0100] generating new key pair for UUID 50b1a5bb-83cd-4251-b674-b3c71a058fc3
     INFO[2021-03-01 18:41:20.664 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: registering public key at key service: https://key.prod.ubirch.com/api/keyService/v1/pubkey
     INFO[2021-03-01 18:41:21.755 +0100] 50b1a5bb-83cd-4251-b674-b3c71a058fc3: submitting CSR to identity service: https://identity.prod.ubirch.com/api/certs/v1/csr/register

--- a/load-test/go.mod
+++ b/load-test/go.mod
@@ -2,4 +2,7 @@ module github.com/ubirch/load-test
 
 go 1.16
 
-require github.com/sirupsen/logrus v1.8.1
+require (
+	github.com/sirupsen/logrus v1.8.1
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5
+)

--- a/load-test/helper.go
+++ b/load-test/helper.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
@@ -70,7 +71,7 @@ type chainChecker struct {
 	signaturesMutex sync.RWMutex
 }
 
-func (c *chainChecker) checkChain(uppBytes <-chan []byte) {
+func (c *chainChecker) checkChain(uppBytes <-chan []byte, cancel context.CancelFunc) {
 	for b := range uppBytes {
 		upp, err := ubirch.Decode(b)
 		if err != nil {
@@ -97,6 +98,8 @@ func (c *chainChecker) checkChain(uppBytes <-chan []byte) {
 
 		c.SetSignature(id, signatureUPP)
 	}
+
+	cancel()
 }
 
 func (c *chainChecker) GetSignature(id string) []byte {

--- a/load-test/helper.go
+++ b/load-test/helper.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
 	"net/http"
 	"os"
 	"sync"
+
+	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
 
 	log "github.com/sirupsen/logrus"
 )

--- a/load-test/helper.go
+++ b/load-test/helper.go
@@ -72,6 +72,8 @@ type chainChecker struct {
 }
 
 func (c *chainChecker) checkChain(uppBytes <-chan []byte, cancel context.CancelFunc) {
+	defer cancel()
+
 	for b := range uppBytes {
 		upp, err := ubirch.Decode(b)
 		if err != nil {
@@ -98,8 +100,6 @@ func (c *chainChecker) checkChain(uppBytes <-chan []byte, cancel context.CancelF
 
 		c.SetSignature(id, signatureUPP)
 	}
-
-	cancel()
 }
 
 func (c *chainChecker) GetSignature(id string) []byte {

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -29,7 +30,8 @@ func main() {
 
 	cc := chainChecker{signatures: make(map[string][]byte, numberOfTestIDs)}
 	ccChan := make(chan []byte)
-	go cc.checkChain(ccChan)
+	ctx, cancel := context.WithCancel(context.Background())
+	go cc.checkChain(ccChan, cancel)
 
 	start := time.Now()
 
@@ -40,6 +42,7 @@ func main() {
 	log.Infof(" = = = => requests sent after %7.3f seconds <= = = = ", time.Since(start).Seconds())
 	wg.Wait()
 	close(ccChan)
+	<-ctx.Done()
 	log.Infof(" = = = => requests done after %7.3f seconds <= = = = ", time.Since(start).Seconds())
 }
 

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -41,9 +41,9 @@ func main() {
 
 	log.Infof(" = = = => requests sent after %7.3f seconds <= = = = ", time.Since(start).Seconds())
 	wg.Wait()
+	log.Infof(" = = = => requests done after %7.3f seconds <= = = = ", time.Since(start).Seconds())
 	close(ccChan)
 	<-ctx.Done()
-	log.Infof(" = = = => requests done after %7.3f seconds <= = = = ", time.Since(start).Seconds())
 }
 
 func sendRequests(id string, auth string, ccChan chan<- []byte, wg *sync.WaitGroup) {

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -14,9 +14,9 @@ import (
 
 const (
 	clientBaseURL         = "http://localhost:8080/"
-	configFile            = "../main/config.json"
-	numberOfTestIDs       = 100
-	numberOfRequestsPerID = 50
+	configFile            = "config.json"
+	numberOfTestIDs       = 1000
+	numberOfRequestsPerID = 5
 )
 
 func main() {
@@ -24,14 +24,18 @@ func main() {
 	var wg sync.WaitGroup
 
 	testIdentities := getTestIdentities(numberOfTestIDs)
+	log.Infof("%d identities, %d requests each", numberOfTestIDs, numberOfRequestsPerID)
+	log.Infof(" = = = => sending %d requests <= = = = ", numberOfTestIDs*numberOfRequestsPerID)
+
+	start := time.Now()
 
 	for uid, auth := range testIdentities {
 		sendRequests(uid, auth, &wg)
 	}
 
-	log.Debug("waiting...")
+	log.Infof(" = = = => %d requests sent after %f seconds <= = = = ", numberOfTestIDs*numberOfRequestsPerID, time.Since(start).Seconds())
 	wg.Wait()
-	log.Info("done")
+	log.Infof(" = = = => done after %f seconds <= = = = ", time.Since(start).Seconds())
 }
 
 func sendRequests(id string, auth string, wg *sync.WaitGroup) {
@@ -44,6 +48,8 @@ func sendRequests(id string, auth string, wg *sync.WaitGroup) {
 	for i := 1; i <= numberOfRequestsPerID; i++ {
 		wg.Add(1)
 		go sendAndCheckResponse(HTTPclient, clientURL, header, wg)
+
+		time.Sleep(time.Second / numberOfRequestsPerID)
 	}
 }
 

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -15,8 +15,8 @@ import (
 const (
 	clientBaseURL         = "http://localhost:8080/"
 	configFile            = "config.json"
-	numberOfTestIDs       = 1000
-	numberOfRequestsPerID = 5
+	numberOfTestIDs       = 2000
+	numberOfRequestsPerID = 3
 )
 
 func main() {
@@ -33,9 +33,9 @@ func main() {
 		sendRequests(uid, auth, &wg)
 	}
 
-	log.Infof(" = = = => requests sent after %f seconds <= = = = ", time.Since(start).Seconds())
+	log.Infof(" = = = => requests sent after %7.3f seconds <= = = = ", time.Since(start).Seconds())
 	wg.Wait()
-	log.Infof(" = = = => requests done after %f seconds <= = = = ", time.Since(start).Seconds())
+	log.Infof(" = = = => requests done after %7.3f seconds <= = = = ", time.Since(start).Seconds())
 }
 
 func sendRequests(id string, auth string, wg *sync.WaitGroup) {

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -24,8 +24,8 @@ func main() {
 	var wg sync.WaitGroup
 
 	testIdentities := getTestIdentities(numberOfTestIDs)
-	log.Infof("%d identities, %d requests each", numberOfTestIDs, numberOfRequestsPerID)
-	log.Infof(" = = = => sending %d requests <= = = = ", numberOfTestIDs*numberOfRequestsPerID)
+	log.Infof("%d identities, %d requests each", len(testIdentities), numberOfRequestsPerID)
+	log.Infof(" = = = => sending %d requests <= = = = ", len(testIdentities)*numberOfRequestsPerID)
 
 	start := time.Now()
 
@@ -33,9 +33,9 @@ func main() {
 		sendRequests(uid, auth, &wg)
 	}
 
-	log.Infof(" = = = => %d requests sent after %f seconds <= = = = ", numberOfTestIDs*numberOfRequestsPerID, time.Since(start).Seconds())
+	log.Infof(" = = = => requests sent after %f seconds <= = = = ", time.Since(start).Seconds())
 	wg.Wait()
-	log.Infof(" = = = => done after %f seconds <= = = = ", time.Since(start).Seconds())
+	log.Infof(" = = = => requests done after %f seconds <= = = = ", time.Since(start).Seconds())
 }
 
 func sendRequests(id string, auth string, wg *sync.WaitGroup) {

--- a/main/client.go
+++ b/main/client.go
@@ -91,7 +91,7 @@ func ubirchHeader(uid uuid.UUID, auth string) map[string]string {
 func post(url string, data []byte, header map[string]string) (HTTPResponse, error) {
 	client := &http.Client{Timeout: BackendRequestTimeout}
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
 	if err != nil {
 		return HTTPResponse{}, fmt.Errorf("can't make new post request: %v", err)
 	}

--- a/main/client.go
+++ b/main/client.go
@@ -167,5 +167,9 @@ func isKeyRegistered(keyService string, id uuid.UUID, pubKey []byte) (bool, erro
 }
 
 func httpFailed(StatusCode int) bool {
-	return !(StatusCode >= 200 && StatusCode < 300)
+	return !httpSuccess(StatusCode)
+}
+
+func httpSuccess(StatusCode int) bool {
+	return StatusCode >= 200 && StatusCode < 300
 }

--- a/main/config.go
+++ b/main/config.go
@@ -252,7 +252,7 @@ func (c *Config) setDefaultURLs() error {
 		return fmt.Errorf("invalid UBIRCH backend environment: \"%s\"", c.Env)
 	}
 
-	log.Infof("UBIRCH backend \"%s\" environment", c.Env)
+	log.Infof("UBIRCH backend env: %s", c.Env)
 
 	if c.KeyService == "" {
 		c.KeyService = fmt.Sprintf(defaultKeyURL, c.Env)

--- a/main/config.go
+++ b/main/config.go
@@ -238,7 +238,7 @@ func (c *Config) setDefaultReqBufSize() {
 	if c.RequestBufSize == 0 {
 		c.RequestBufSize = defaultReqBufSize
 	}
-	log.Debugf("Request Buffer Size: %d", c.RequestBufSize)
+	log.Debugf("request buffer size: %d", c.RequestBufSize)
 }
 
 func (c *Config) setDefaultURLs() error {

--- a/main/config.go
+++ b/main/config.go
@@ -38,6 +38,8 @@ const (
 	defaultNiomonURL   = "https://niomon.%s.ubirch.com/"
 	defaultVerifyURL   = "https://verify.%s.ubirch.com/api/upp/verify"
 
+	configFile = "config.json"
+
 	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]} TODO: DEPRECATED
 	authFile = "auth.json"       // {UUID: [key, token]} TODO: DEPRECATED
 
@@ -76,14 +78,14 @@ type Config struct {
 	configDir        string            // directory where config and protocol ctx are stored (set automatically)
 }
 
-func (c *Config) Load(configDir string, filename string) error {
+func (c *Config) Load(configDir string) error {
 	// assume that we want to load from env instead of config files, if
 	// we have the UBIRCH_SECRET env variable set.
 	var err error
 	if os.Getenv("UBIRCH_SECRET") != "" {
 		err = c.loadEnv()
 	} else {
-		err = c.loadFile(filepath.Join(configDir, filename))
+		err = c.loadFile(filepath.Join(configDir, configFile))
 	}
 	if err != nil {
 		return err

--- a/main/config.go
+++ b/main/config.go
@@ -38,8 +38,6 @@ const (
 	defaultNiomonURL   = "https://niomon.%s.ubirch.com/"
 	defaultVerifyURL   = "https://verify.%s.ubirch.com/api/upp/verify"
 
-	configFile = "config.json"
-
 	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]} TODO: DEPRECATED
 	authFile = "auth.json"       // {UUID: [key, token]} TODO: DEPRECATED
 
@@ -78,14 +76,14 @@ type Config struct {
 	configDir        string            // directory where config and protocol ctx are stored (set automatically)
 }
 
-func (c *Config) Load(configDir string) error {
+func (c *Config) Load(configDir string, filename string) error {
 	// assume that we want to load from env instead of config files, if
 	// we have the UBIRCH_SECRET env variable set.
 	var err error
 	if os.Getenv("UBIRCH_SECRET") != "" {
 		err = c.loadEnv()
 	} else {
-		err = c.loadFile(filepath.Join(configDir, configFile))
+		err = c.loadFile(filepath.Join(configDir, filename))
 	}
 	if err != nil {
 		return err

--- a/main/config.go
+++ b/main/config.go
@@ -190,25 +190,33 @@ func (c *Config) setDefaultTLS(configDir string) {
 	if c.TCP_addr == "" {
 		c.TCP_addr = ":8080"
 	}
+	log.Infof("TCP address: %s", c.TCP_addr)
 
 	if c.TLS {
+		log.Debug("TLS enabled")
+
 		if c.TLS_CertFile == "" {
 			c.TLS_CertFile = defaultTLSCertFile
 		}
 		c.TLS_CertFile = filepath.Join(configDir, c.TLS_CertFile)
+		log.Debugf(" - Cert: %s", c.TLS_CertFile)
 
 		if c.TLS_KeyFile == "" {
 			c.TLS_KeyFile = defaultTLSKeyFile
 		}
 		c.TLS_KeyFile = filepath.Join(configDir, c.TLS_KeyFile)
+		log.Debugf(" -  Key: %s", c.TLS_KeyFile)
 	}
 }
 
 func (c *Config) setDefaultCORS() {
 	if c.CORS {
+		log.Debug("CORS enabled")
+
 		if c.CORS_Origins == nil {
 			c.CORS_Origins = []string{"*"} // allow all origins
 		}
+		log.Debugf(" - Allowed Origins: %v", c.CORS_Origins)
 	}
 }
 

--- a/main/config.go
+++ b/main/config.go
@@ -77,19 +77,19 @@ type Config struct {
 }
 
 func (c *Config) Load(configDir string, filename string) error {
+	c.configDir = configDir
+
 	// assume that we want to load from env instead of config files, if
 	// we have the UBIRCH_SECRET env variable set.
 	var err error
 	if os.Getenv("UBIRCH_SECRET") != "" {
 		err = c.loadEnv()
 	} else {
-		err = c.loadFile(filepath.Join(configDir, filename))
+		err = c.loadFile(filename)
 	}
 	if err != nil {
 		return err
 	}
-
-	c.configDir = configDir
 
 	c.SecretBytes, err = base64.StdEncoding.DecodeString(c.Secret)
 	if err != nil {
@@ -144,9 +144,10 @@ func (c *Config) loadEnv() error {
 
 // LoadFile reads the configuration from a json file
 func (c *Config) loadFile(filename string) error {
-	log.Infof("loading configuration from file: %s", filename)
+	configFile := filepath.Join(c.configDir, filename)
+	log.Infof("loading configuration from file: %s", configFile)
 
-	fileHandle, err := os.Open(filename)
+	fileHandle, err := os.Open(configFile)
 	if err != nil {
 		return err
 	}
@@ -250,7 +251,7 @@ func (c *Config) setDefaultURLs() error {
 		return fmt.Errorf("invalid UBIRCH backend environment: \"%s\"", c.Env)
 	}
 
-	log.Infof("UBIRCH backend env: %s", c.Env)
+	log.Infof("UBIRCH backend environment: %s", c.Env)
 
 	if c.KeyService == "" {
 		c.KeyService = fmt.Sprintf(defaultKeyURL, c.Env)

--- a/main/config.go
+++ b/main/config.go
@@ -97,7 +97,7 @@ func (c *Config) Load(configDir string, filename string) error {
 	}
 
 	if c.Debug {
-		log.SetLevel(log.DebugLevel)
+		log.SetLevel(log.DebugLevel) // TODO: make configurable
 	}
 	if c.LogTextFormat {
 		log.SetFormatter(&log.TextFormatter{FullTimestamp: true, TimestampFormat: "2006-01-02 15:04:05.000 -0700"})

--- a/main/config.go
+++ b/main/config.go
@@ -38,8 +38,8 @@ const (
 	niomonURL   = "https://niomon.%s.ubirch.com/"
 	verifyURL   = "https://verify.%s.ubirch.com/api/upp/verify"
 
-	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]} (legacy)
-	authFile = "auth.json"       // {UUID: [key, token]} (legacy)
+	authEnv  = "UBIRCH_AUTH_MAP" // {UUID: [key, token]} TODO: DEPRECATED
+	authFile = "auth.json"       // {UUID: [key, token]} TODO: DEPRECATED
 
 	identitiesFile = "identities.json" // [{ "uuid": "<uuid>", "password": "<auth>" }]
 
@@ -97,7 +97,7 @@ func (c *Config) Load(configDir string, filename string) error {
 		log.SetFormatter(&log.TextFormatter{FullTimestamp: true, TimestampFormat: "2006-01-02 15:04:05.000 -0700"})
 	}
 
-	err = c.loadAuthMap(configDir) // legacy
+	err = c.loadAuthMap(configDir) // TODO: DEPRECATED
 	if err != nil {
 		return err
 	}
@@ -277,8 +277,9 @@ func (c *Config) loadDeviceIdentitiesFile(configDir string) error {
 	return nil
 }
 
-// loadAuthMap loads the auth map from the environment >> legacy <<
-// Returns without error if neither env variable nor file exists.
+// TODO: DEPRECATED
+//  loadAuthMap loads the auth map from the environment >> legacy <<
+//  Returns without error if neither env variable nor file exists.
 func (c *Config) loadAuthMap(configDir string) error {
 	var err error
 	var authMapBytes []byte

--- a/main/config_test.go
+++ b/main/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const expectedConfig = `{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`
+const expectedConfig = `{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","env":"","DSN":"","staticKeys":false,"keys":null,"CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"RequestBufferSize":0,"SecretBytes":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":""}`
 
 func TestConfig(t *testing.T) {
 	configBytes := []byte(expectedConfig)

--- a/main/database.go
+++ b/main/database.go
@@ -42,6 +42,9 @@ type Postgres struct {
 	conn *sql.DB
 }
 
+// TODO: Ensure Postgres implements the ContextManager interface
+//var _ ContextManager = (*Postgres)(nil)
+
 // NewPostgres takes a database connection string, returns a new initialized
 // database.
 func NewPostgres(dsn string) (*Postgres, error) {

--- a/main/file_manager.go
+++ b/main/file_manager.go
@@ -40,6 +40,10 @@ func NewFileManager(configDir string) (*FileManager, error) {
 		}
 	}
 
+	log.Info("protocol context will be stored in local file system")
+	log.Debugf(" - keystore file: %s", f.keyFile)
+	log.Debugf(" - signature dir: %s", f.signatureDir)
+
 	return f, nil
 }
 

--- a/main/file_manager.go
+++ b/main/file_manager.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -35,7 +34,7 @@ func NewFileManager(configDir string) (*FileManager, error) {
 	}
 
 	if _, err := os.Stat(f.signatureDir); os.IsNotExist(err) {
-		err = os.Mkdir(f.signatureDir, os.FileMode(dirPerm))
+		err = os.Mkdir(f.signatureDir, dirPerm)
 		if err != nil {
 			return nil, err
 		}
@@ -65,7 +64,7 @@ func (f *FileManager) LoadSignature(uid uuid.UUID) ([]byte, error) {
 func (f *FileManager) PersistSignature(uid uuid.UUID, signature []byte) error {
 	signatureFile := f.getSignatureFile(uid)
 
-	return ioutil.WriteFile(signatureFile, signature, fs.FileMode(filePerm))
+	return ioutil.WriteFile(signatureFile, signature, filePerm)
 }
 
 func (f *FileManager) Close() error {
@@ -108,5 +107,5 @@ func persistFile(file string, source interface{}) error {
 		}
 	}
 	contextBytes, _ := json.MarshalIndent(source, "", "  ")
-	return ioutil.WriteFile(file, contextBytes, fs.FileMode(filePerm))
+	return ioutil.WriteFile(file, contextBytes, filePerm)
 }

--- a/main/file_manager.go
+++ b/main/file_manager.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	keyFileName       = "keys.json"
+	SignatureFileName = "signatures.json"
+)
+
+type FileManager struct {
+	keyFile       string
+	signatureFile string
+}
+
+// Ensure FileManager implements the ContextManager interface
+var _ ContextManager = (*FileManager)(nil)
+
+func NewFileManager(contextDir string) *FileManager {
+	return &FileManager{
+		keyFile:       filepath.Join(contextDir, keyFileName),
+		signatureFile: filepath.Join(contextDir, SignatureFileName),
+	}
+}
+
+func (f *FileManager) LoadKeys(dest interface{}) error {
+	return loadFile(f.keyFile, dest)
+}
+
+func (f *FileManager) PersistKeys(source interface{}) error {
+	return persistFile(f.keyFile, source)
+}
+
+func (f *FileManager) LoadSignatures(dest interface{}) error {
+	return loadFile(f.signatureFile, dest)
+}
+
+func (f *FileManager) PersistSignatures(source interface{}) error {
+	return persistFile(f.signatureFile, source)
+}
+
+func (f *FileManager) Close() error {
+	return nil
+}
+
+func loadFile(file string, dest interface{}) error {
+	if _, err := os.Stat(file); os.IsNotExist(err) { // if file does not exist yet, return right away
+		return nil
+	}
+	contextBytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		file = file + ".bck"
+		contextBytes, err = ioutil.ReadFile(file)
+		if err != nil {
+			return err
+		}
+	}
+	err = json.Unmarshal(contextBytes, dest)
+	if err != nil {
+		if strings.HasSuffix(file, ".bck") {
+			return err
+		} else {
+			return loadFile(file+".bck", dest)
+		}
+	}
+	return nil
+}
+
+func persistFile(file string, source interface{}) error {
+	if _, err := os.Stat(file); !os.IsNotExist(err) { // if file already exists, create a backup
+		err = os.Rename(file, file+".bck")
+		if err != nil {
+			log.Warnf("unable to create backup file for %s: %v", file, err)
+		}
+	}
+	contextBytes, _ := json.MarshalIndent(source, "", "  ")
+	return ioutil.WriteFile(file, contextBytes, 444)
+}

--- a/main/file_manager.go
+++ b/main/file_manager.go
@@ -2,17 +2,22 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/google/uuid"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
 	keyFileName      = "keys.json"
 	SignatureDirName = "signatures"
+	filePerm         = 0644
+	dirPerm          = 0755
 )
 
 type FileManager struct {
@@ -30,7 +35,7 @@ func NewFileManager(configDir string) (*FileManager, error) {
 	}
 
 	if _, err := os.Stat(f.signatureDir); os.IsNotExist(err) {
-		err = os.Mkdir(f.signatureDir, 555)
+		err = os.Mkdir(f.signatureDir, os.FileMode(dirPerm))
 		if err != nil {
 			return nil, err
 		}
@@ -60,7 +65,7 @@ func (f *FileManager) LoadSignature(uid uuid.UUID) ([]byte, error) {
 func (f *FileManager) PersistSignature(uid uuid.UUID, signature []byte) error {
 	signatureFile := f.getSignatureFile(uid)
 
-	return ioutil.WriteFile(signatureFile, signature, 444)
+	return ioutil.WriteFile(signatureFile, signature, fs.FileMode(filePerm))
 }
 
 func (f *FileManager) Close() error {
@@ -103,5 +108,5 @@ func persistFile(file string, source interface{}) error {
 		}
 	}
 	contextBytes, _ := json.MarshalIndent(source, "", "  ")
-	return ioutil.WriteFile(file, contextBytes, 444)
+	return ioutil.WriteFile(file, contextBytes, fs.FileMode(filePerm))
 }

--- a/main/go.mod
+++ b/main/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/lib/pq v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310233515-4e2042e57805
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20210405124814-9dd258c160b5
 	golang.org/x/net v0.0.0-20210331060903-cb1fcc7394e5 // indirect
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )

--- a/main/go.sum
+++ b/main/go.sum
@@ -23,8 +23,8 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IKw=
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310233515-4e2042e57805 h1:1wK1vzvzNnnY3+pfXHqcsk/D8JW+sKsN31wXvfeJ4mk=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.5-0.20210310233515-4e2042e57805/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20210405124814-9dd258c160b5 h1:zQdj6AFXr8q4nhNqhQC34V6n1i6WPD0Z7MO1wN9/YpQ=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20210405124814-9dd258c160b5/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -64,12 +64,12 @@ type Service interface {
 	handleRequest(w http.ResponseWriter, r *http.Request)
 }
 
-type AnchoringService struct {
+type ChainingService struct {
 	*Signer
 	AuthTokens map[string]string
 }
 
-type UpdateOperationService struct {
+type UpdateService struct {
 	*Signer
 	AuthTokens map[string]string
 }
@@ -78,7 +78,7 @@ type VerificationService struct {
 	*Verifier
 }
 
-func (service *AnchoringService) handleRequest(w http.ResponseWriter, r *http.Request) {
+func (service *ChainingService) handleRequest(w http.ResponseWriter, r *http.Request) {
 	var msg HTTPRequest
 	var err error
 
@@ -116,15 +116,18 @@ func (service *AnchoringService) handleRequest(w http.ResponseWriter, r *http.Re
 		return
 	}
 
+	// wait for response or timeout
 	select {
 	case <-r.Context().Done():
 		log.Errorf("%s: 504 Gateway Timeout", msg.ID)
 	case resp := <-msg.Response:
 		sendResponse(w, resp)
+	case <-r.Context().Done():
+		log.Errorf("%s: %v", msg.ID, r.Context().Err())
 	}
 }
 
-func (service *UpdateOperationService) handleRequest(w http.ResponseWriter, r *http.Request) {
+func (service *UpdateService) handleRequest(w http.ResponseWriter, r *http.Request) {
 	var msg HTTPRequest
 	var err error
 

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -118,8 +118,6 @@ func (service *ChainingService) handleRequest(w http.ResponseWriter, r *http.Req
 
 	// wait for response or timeout
 	select {
-	case <-r.Context().Done():
-		log.Errorf("%s: 504 Gateway Timeout", msg.ID)
 	case resp := <-msg.Response:
 		sendResponse(w, resp)
 	case <-r.Context().Done():

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -351,9 +351,6 @@ func (srv *HTTPServer) SetUpCORS(allowedOrigins []string, debug bool) {
 		MaxAge:           300, // Maximum value not ignored by any of major browsers
 		Debug:            debug,
 	}))
-
-	log.Printf("CORS enabled")
-	log.Debugf(" - Allowed Origins: %v", allowedOrigins)
 }
 
 func (srv *HTTPServer) AddEndpoint(endpoint ServerEndpoint) {
@@ -389,11 +386,6 @@ func (srv *HTTPServer) Serve(ctx context.Context) error {
 		}
 	}()
 
-	if srv.TLS {
-		log.Info("TLS enabled")
-		log.Debugf(" - Cert: %s", srv.certFile)
-		log.Debugf(" -  Key: %s", srv.keyFile)
-	}
 	log.Infof("starting HTTP server")
 
 	var err error

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -18,7 +18,9 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/google/uuid"
+
 	log "github.com/sirupsen/logrus"
 )
 

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -69,7 +69,7 @@ func submitCSR(p *ExtendedProtocol, uid uuid.UUID, subjectCountry string, subjec
 }
 
 func initDeviceKeys(p *ExtendedProtocol, conf Config) error {
-	err := p.LoadContext() // fails if p not initialized
+	err := p.LoadKeys()
 	if err != nil {
 		return fmt.Errorf("unable to load protocol context: %v", err)
 	}
@@ -119,7 +119,7 @@ func initDeviceKeys(p *ExtendedProtocol, conf Config) error {
 			}
 
 			// store newly generated key in persistent storage
-			err = p.PersistContext()
+			err = p.PersistKeys()
 			if err != nil {
 				return fmt.Errorf("unable to persist new key pair for UUID %s: %v", name, err)
 			}
@@ -156,7 +156,7 @@ func initDeviceKeys(p *ExtendedProtocol, conf Config) error {
 		if _, found := p.Signatures[uid]; !found {
 			p.Signatures[uid] = make([]byte, 64)
 
-			err = p.PersistContext()
+			err = p.PersistSignatures()
 			if err != nil {
 				return fmt.Errorf("unable to persist protocol context: %v", err)
 			}

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -151,16 +151,6 @@ func initDeviceKeys(p *ExtendedProtocol, conf Config) error {
 			log.Errorf("submitting CSR for UUID %s failed: %v", name, err)
 		}
 
-		//  explicitly set prev. signature to all zeroes in protocol context if UUID does not have a prev. signature
-		// in order to be able to reset the prev. signature to all zeroes in case sending of the first UPP fails
-		if _, found := p.Signatures[uid]; !found {
-			p.Signatures[uid] = make([]byte, 64)
-
-			err = p.PersistSignatures()
-			if err != nil {
-				return fmt.Errorf("unable to persist protocol context: %v", err)
-			}
-		}
 	}
 	return nil
 }

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -68,7 +68,11 @@ func injectKeys(p *ExtendedProtocol, keys map[string]string) error {
 		}
 		err = p.SetKey(name, uid, keyBytes)
 		if err != nil {
-			return fmt.Errorf("unable to insert private key to protocol context: %v", err)
+			return fmt.Errorf("unable to inject key to keystore: %v", err)
+		}
+		err = p.PersistKeys()
+		if err != nil {
+			return fmt.Errorf("unable to persist injected key for UUID %s: %v", uid, err)
 		}
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -113,7 +113,7 @@ func main() {
 		protocol:       p,
 		env:            conf.Env,
 		authServiceURL: conf.Niomon,
-		MessageHandler: make(chan HTTPRequest, 150), // 3rps * 50s // TODO: make configurable
+		MessageHandler: make(chan HTTPRequest, conf.RequestBufSize),
 	}
 
 	// start synchronous chaining routine

--- a/main/main.go
+++ b/main/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 	p.Signatures = map[uuid.UUID][]byte{}
 
-	err = p.Init(configDir, contextFile, conf.DSN, conf.Keys)
+	err = p.Init(configDir, contextFile, conf.DSN)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -41,9 +41,8 @@ func shutdown(cancel context.CancelFunc) {
 
 func main() {
 	const (
-		Version    = "v2.0.0"
-		Build      = "local"
-		configFile = "config.json"
+		Version = "v2.0.0"
+		Build   = "local"
 	)
 
 	var configDir string
@@ -56,7 +55,7 @@ func main() {
 
 	// read configuration
 	conf := Config{}
-	err := conf.Load(configDir, configFile)
+	err := conf.Load(configDir)
 	if err != nil {
 		log.Fatalf("ERROR: unable to load configuration: %s", err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -116,34 +116,37 @@ func main() {
 		return s.chainer()
 	})
 
-	// set up endpoint for hash anchoring
+	// set up endpoint for chaining
 	httpServer.AddEndpoint(ServerEndpoint{
 		Path: fmt.Sprintf("/{%s}", UUIDKey),
-		Service: &AnchoringService{
+		Service: &ChainingService{
 			Signer:     &s,
 			AuthTokens: conf.Devices,
 		},
 	})
 
-	// set up endpoint for hash update operations
+	// set up endpoint for update operations
 	httpServer.AddEndpoint(ServerEndpoint{
 		Path: fmt.Sprintf("/{%s}/{%s}", UUIDKey, OperationKey),
-		Service: &UpdateOperationService{
+		Service: &UpdateService{
 			Signer:     &s,
 			AuthTokens: conf.Devices,
 		},
 	})
 
-	// set up endpoint for hash verification
+	// initialize verifier
+	v := Verifier{
+		protocol:                      &p,
+		verifyServiceURL:              conf.VerifyService,
+		keyServiceURL:                 conf.KeyService,
+		verifyFromKnownIdentitiesOnly: false, // TODO: make configurable
+	}
+
+	// set up endpoint for verification
 	httpServer.AddEndpoint(ServerEndpoint{
 		Path: "/verify",
 		Service: &VerificationService{
-			Verifier: &Verifier{
-				protocol:                      &p,
-				verifyServiceURL:              conf.VerifyService,
-				keyServiceURL:                 conf.KeyService,
-				verifyFromKnownIdentitiesOnly: false, // TODO: make configurable
-			},
+			Verifier: &v,
 		},
 	})
 

--- a/main/main.go
+++ b/main/main.go
@@ -71,8 +71,20 @@ func main() {
 		Names:    map[string]uuid.UUID{},
 	}
 	p.Signatures = map[uuid.UUID][]byte{}
+	p.contextFile_Legacy = filepath.Join(configDir, contextFile)
 
-	err = p.Init(configDir, contextFile, conf.DSN)
+	if conf.DSN != "" {
+		log.Fatalf("database not supported in current version")
+		// FIXME // use the database
+		//p.ctxManager, err = NewPostgres(conf.DSN)
+		//if err != nil {
+		//	return fmt.Errorf("unable to connect to database: %v", err)
+		//}
+	} else {
+		p.ctxManager = NewFileManager(configDir)
+	}
+
+	err = p.Init()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main/main.go
+++ b/main/main.go
@@ -41,8 +41,9 @@ func shutdown(cancel context.CancelFunc) {
 
 func main() {
 	const (
-		Version = "v2.0.0"
-		Build   = "local"
+		Version    = "v2.0.0"
+		Build      = "local"
+		configFile = "config.json"
 	)
 
 	var configDir string
@@ -55,7 +56,7 @@ func main() {
 
 	// read configuration
 	conf := Config{}
-	err := conf.Load(configDir)
+	err := conf.Load(configDir, configFile)
 	if err != nil {
 		log.Fatalf("ERROR: unable to load configuration: %s", err)
 	}

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -29,34 +29,49 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const (
+	keyFileName       = "keys.json"
+	SignatureFileName = "signatures.json"
+)
+
 type ExtendedProtocol struct {
 	ubirch.Protocol
-	db          Database
-	contextFile string
+	db                 Database
+	contextFile_Legacy string
 }
 
 // Init sets keys in crypto context and updates keystore in persistent storage
 func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string) error {
 	// check if we want to use a database as persistent storage
 	if dsn != "" {
-		// use the database
-		db, err := NewPostgres(dsn)
-		if err != nil {
-			return fmt.Errorf("unable to connect to database: %v", err)
-		}
-		p.db = db
-		log.Printf("protocol context will be saved to database")
+		// FIXME // use the database
+		//db, err := NewPostgres(dsn)
+		//if err != nil {
+		//	return fmt.Errorf("unable to connect to database: %v", err)
+		//}
+		//p.db = db
+		//log.Printf("protocol context will be saved to database")
+		log.Fatalf("database not supported in current version")
 	} else if filename != "" {
-		p.contextFile = filepath.Join(configDir, filename)
-		log.Printf("protocol context will be saved to file: %s", p.contextFile)
+		p.contextFile_Legacy = filepath.Join(configDir, filename)
+		log.Printf("protocol context will be saved to files")
 	} else {
 		return fmt.Errorf("neither DSN nor filename for protocol context set")
 	}
 
-	// try to read an existing protocol context from persistent storage (keystore, last signatures, CSRs)
-	err := p.LoadContext()
+	err := p.portLegacyProtocolCtxFile()
 	if err != nil {
-		return fmt.Errorf("unable to load protocol context: %v", err)
+		return err
+	}
+
+	err = p.LoadKeys()
+	if err != nil {
+		return err
+	}
+
+	err = p.LoadSignatures()
+	if err != nil {
+		return err
 	}
 
 	if len(p.Signatures) != 0 {
@@ -74,40 +89,73 @@ func (p *ExtendedProtocol) Deinit() error {
 	return nil
 }
 
-// PersistContext saves current ubirch-protocol context, storing keystore, key certificates and signatures
-func (p *ExtendedProtocol) PersistContext() error {
-	if p.db != nil {
-		return p.db.SetProtocolContext(p)
-	} else if p.contextFile != "" {
-		return p.saveFile(p.contextFile)
-	} else {
-		return fmt.Errorf("DB / file for protocol context not initialized")
-	}
+func (p *ExtendedProtocol) LoadKeys() error {
+	return loadFile(keyFileName, &p.Crypto) // todo filepath.Join(configDir, filename)
 }
 
-// LoadContext loads current ubirch-protocol context, loading keys and signatures
-func (p *ExtendedProtocol) LoadContext() error {
-	if p.db != nil {
-		return p.db.GetProtocolContext(p)
-	} else if p.contextFile != "" {
-		return p.loadFile(p.contextFile)
-	} else {
-		return fmt.Errorf("DB / file for protocol context not initialized")
-	}
+func (p *ExtendedProtocol) PersistKeys() error {
+	return persistFile(keyFileName, &p.Crypto) // todo filepath.Join(configDir, filename)
 }
 
-func (p *ExtendedProtocol) saveFile(file string) error {
+func (p *ExtendedProtocol) LoadSignatures() error {
+	return loadFile(SignatureFileName, &p.Signatures) // todo filepath.Join(configDir, filename)
+}
+
+func (p *ExtendedProtocol) PersistSignatures() error {
+	return persistFile(SignatureFileName, &p.Signatures) // todo filepath.Join(configDir, filename)
+}
+
+func (p *ExtendedProtocol) portLegacyProtocolCtxFile() error {
+	if p.contextFile_Legacy == "" {
+		return nil
+	}
+	if _, err := os.Stat(p.contextFile_Legacy); os.IsNotExist(err) { // if file does not exist, return right away
+		return nil
+	}
+
+	// read legacy protocol context from persistent storage
+	err := loadFile(p.contextFile_Legacy, p)
+	if err != nil {
+		return fmt.Errorf("unable to load protocol context: %v", err)
+	}
+
+	// persist loaded keys to new key storage
+	err = p.PersistKeys()
+	if err != nil {
+		return fmt.Errorf("unable to persist keys: %v", err)
+	}
+
+	// persist loaded signatures to new signature storage
+	err = p.PersistSignatures()
+	if err != nil {
+		return fmt.Errorf("unable to persist signatures: %v", err)
+	}
+
+	// delete legacy protocol ctx file + bckup
+	err = os.Remove(p.contextFile_Legacy)
+	if err != nil {
+		return fmt.Errorf("unable to delete legacy protocol context file: %v", err)
+	}
+	err = os.Remove(p.contextFile_Legacy + ".bck")
+	if err != nil {
+		log.Errorf("unable to delete legacy protocol context backup file: %v", err)
+	}
+
+	return nil
+}
+
+func persistFile(file string, source interface{}) error {
 	if _, err := os.Stat(file); !os.IsNotExist(err) { // if file already exists, create a backup
 		err = os.Rename(file, file+".bck")
 		if err != nil {
 			log.Warnf("unable to create backup file for %s: %v", file, err)
 		}
 	}
-	contextBytes, _ := json.MarshalIndent(p, "", "  ")
+	contextBytes, _ := json.MarshalIndent(source, "", "  ")
 	return ioutil.WriteFile(file, contextBytes, 444)
 }
 
-func (p *ExtendedProtocol) loadFile(file string) error {
+func loadFile(file string, dest interface{}) error {
 	if _, err := os.Stat(file); os.IsNotExist(err) { // if file does not exist yet, return right away
 		return nil
 	}
@@ -119,12 +167,12 @@ func (p *ExtendedProtocol) loadFile(file string) error {
 			return err
 		}
 	}
-	err = json.Unmarshal(contextBytes, p)
+	err = json.Unmarshal(contextBytes, dest)
 	if err != nil {
 		if strings.HasSuffix(file, ".bck") {
 			return err
 		} else {
-			return p.loadFile(file + ".bck")
+			return loadFile(file+".bck", dest)
 		}
 	}
 	return nil
@@ -132,7 +180,7 @@ func (p *ExtendedProtocol) loadFile(file string) error {
 
 // Value lets the struct implement the driver.Valuer interface. This method
 // simply returns the JSON-encoded representation of the struct.
-func (p ExtendedProtocol) Value() (driver.Value, error) {
+func (p *ExtendedProtocol) Value() (driver.Value, error) {
 	return json.Marshal(p)
 }
 
@@ -143,5 +191,5 @@ func (p *ExtendedProtocol) Scan(value interface{}) error {
 	if !ok {
 		return errors.New("type assertion to []byte failed")
 	}
-	return json.Unmarshal(b, &p)
+	return json.Unmarshal(b, p)
 }

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"database/sql/driver"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,7 +24,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
 
 	log "github.com/sirupsen/logrus"
@@ -38,7 +36,7 @@ type ExtendedProtocol struct {
 }
 
 // Init sets keys in crypto context and updates keystore in persistent storage
-func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, keys map[string]string) error {
+func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string) error {
 	// check if we want to use a database as persistent storage
 	if dsn != "" {
 		// use the database
@@ -63,30 +61,6 @@ func (p *ExtendedProtocol) Init(configDir string, filename string, dsn string, k
 
 	if len(p.Signatures) != 0 {
 		log.Printf("loaded existing protocol context: %d signatures", len(p.Signatures))
-	}
-
-	if keys != nil {
-		// inject keys from configuration to keystore
-		for name, key := range keys {
-			uid, err := uuid.Parse(name)
-			if err != nil {
-				return fmt.Errorf("unable to parse key name %s from key map to UUID: %v", name, err)
-			}
-			keyBytes, err := base64.StdEncoding.DecodeString(key)
-			if err != nil {
-				return fmt.Errorf("unable to decode private key string for %s: %v, string was: %s", name, err, key)
-			}
-			err = p.SetKey(name, uid, keyBytes)
-			if err != nil {
-				return fmt.Errorf("unable to insert private key to protocol context: %v", err)
-			}
-		}
-
-		// update keystore in persistent storage
-		err = p.PersistContext()
-		if err != nil {
-			return fmt.Errorf("unable to store keys: %v", err)
-		}
 	}
 	return nil
 }

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -19,11 +19,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
-	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
 	"os"
 	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const contextFileName_Legacy = "protocol.json" // TODO: DEPRECATED

--- a/main/protocol.go
+++ b/main/protocol.go
@@ -81,7 +81,6 @@ func (p *ExtendedProtocol) LoadSignature(uid uuid.UUID) ([]byte, error) {
 	return p.ctxManager.LoadSignature(uid)
 }
 
-// this is here only for the purpose of backwards compatibility TODO: DEPRECATED
 func (p *ExtendedProtocol) PersistSignature(uid uuid.UUID, signature []byte) error {
 	if len(signature) != p.SignatureLength() {
 		return fmt.Errorf("invalid signature length: expected %d, got %d", p.SignatureLength(), len(signature))
@@ -123,12 +122,13 @@ func (p *ExtendedProtocol) portLegacyProtocolCtxFile(configDir string) error {
 	}
 	err = os.Remove(contextFile_Legacy + ".bck")
 	if err != nil {
-		log.Errorf("unable to delete legacy protocol context backup file: %v", err)
+		log.Warnf("unable to delete legacy protocol context backup file: %v", err)
 	}
 
 	return nil
 }
 
+// this is here only for the purpose of backwards compatibility TODO: DEPRECATED
 func (p *ExtendedProtocol) persistSignatures() error {
 	for uid, signature := range p.Signatures {
 		err := p.PersistSignature(uid, signature)

--- a/main/signer.go
+++ b/main/signer.go
@@ -85,7 +85,7 @@ func (s *Signer) chainer() error {
 			s.protocol.Signatures[msg.ID] = prevSign
 		} else {
 			// persist last signature after UPP was successfully received in ubirch backend
-			err := s.protocol.PersistContext()
+			err := s.protocol.PersistSignatures()
 			if err != nil {
 				return fmt.Errorf("unable to persist last signature: %v [\"%s\": \"%s\"]",
 					err, msg.ID.String(), base64.StdEncoding.EncodeToString(s.protocol.Signatures[msg.ID]))

--- a/main/signer.go
+++ b/main/signer.go
@@ -22,8 +22,9 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	log "github.com/sirupsen/logrus"
 	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type operation string

--- a/main/signer.go
+++ b/main/signer.go
@@ -37,6 +37,13 @@ const (
 	lenRequestID = 16
 )
 
+var hintLookup = map[operation]ubirch.Hint{
+	anchorHash:  ubirch.Binary,
+	disableHash: ubirch.Disable,
+	enableHash:  ubirch.Enable,
+	deleteHash:  ubirch.Delete,
+}
+
 type signingResponse struct {
 	Error     string       `json:"error,omitempty"`
 	Operation operation    `json:"operation,omitempty"`
@@ -50,7 +57,6 @@ type Signer struct {
 	protocol       *ExtendedProtocol
 	env            string
 	authServiceURL string
-	MessageHandler chan HTTPRequest
 }
 
 // non-blocking sending to response channel. returns right away if there is no receiver
@@ -62,76 +68,89 @@ func (msg HTTPRequest) respond(resp HTTPResponse) {
 	}
 }
 
-// handle incoming messages, create, sign and send a ubirch protocol packet (UPP) to the ubirch backend
-func (s *Signer) chainer() error {
-	for msg := range s.MessageHandler {
+// handle incoming messages, create, sign and send a chained ubirch protocol packet (UPP) to the ubirch backend
+func (s *Signer) chainer(jobs <-chan HTTPRequest) error {
+	log.Debugf("starting chainer")
+
+	for msg := range jobs {
 		// the message might have waited in the channel for a while
 		// check if the context is expired or canceled by now
 		if msg.RequestCtx.Err() != nil {
 			continue
 		}
 
-		// buffer last previous signature to be able to reset it in case sending UPP to backend fails
-		prevSign, found := s.protocol.Signatures[msg.ID]
-		if !found {
-			prevSign = make([]byte, 64)
+		log.Infof("%s: anchor hash [chained]: %s", msg.ID, base64.StdEncoding.EncodeToString(msg.Hash[:]))
+
+		upp, err := s.getChainedUPP(msg.ID, msg.Hash[:])
+		if err != nil {
+			log.Errorf("%s: could not create UBIRCH Protocol Package: %v", msg.ID, err)
+			msg.Response <- errorResponse(http.StatusInternalServerError, "")
+			continue // todo should this be fatal?
 		}
 
-		resp := s.handleSigningRequest(msg)
+		resp := s.sendUPP(msg, upp)
+
 		msg.respond(resp)
 
-		if httpFailed(resp.StatusCode) {
-			// reset previous signature in protocol context to ensure intact chain
-			s.protocol.Signatures[msg.ID] = prevSign
-		} else {
-			// persist last signature after UPP was successfully received in ubirch backend
-			err := s.protocol.PersistSignatures()
+		// persist last signature only if UPP was successfully received by ubirch backend
+		if httpSuccess(resp.StatusCode) {
+			signature := upp[len(upp)-s.protocol.SignatureLength():]
+			err := s.protocol.PersistSignature(msg.ID, signature)
 			if err != nil {
 				return fmt.Errorf("unable to persist last signature: %v [\"%s\": \"%s\"]",
-					err, msg.ID.String(), base64.StdEncoding.EncodeToString(s.protocol.Signatures[msg.ID]))
+					err, msg.ID, base64.StdEncoding.EncodeToString(signature))
 			}
 		}
 	}
 
-	log.Debug("shutting down signer")
+	log.Debugf("shutting down chainer")
 	return nil
 }
 
-func (s *Signer) handleSigningRequest(msg HTTPRequest) HTTPResponse {
-	name := msg.ID.String()
-	hash := msg.Hash[:]
-	auth := msg.Auth
+func (s *Signer) updateHash(msg HTTPRequest) HTTPResponse {
+	log.Infof("%s: %s hash: %s", msg.ID, msg.Operation, base64.StdEncoding.EncodeToString(msg.Hash[:]))
 
-	// create and sign a UPP containing the hash
-	var upp []byte
-	var err error
-
-	switch msg.Operation {
-	case anchorHash:
-		upp, err = s.anchorHash(name, hash)
-	case disableHash:
-		upp, err = s.disableHash(name, hash)
-	case enableHash:
-		upp, err = s.enableHash(name, hash)
-	case deleteHash:
-		upp, err = s.deleteHash(name, hash)
-	default:
-		err = fmt.Errorf("unsupported operation: \"%s\"", msg.Operation)
-	}
-
+	upp, err := s.getSignedUPP(msg.ID, msg.Hash[:], msg.Operation)
 	if err != nil {
-		log.Errorf("%s: could not create UBIRCH Protocol Package: %v", name, err)
+		log.Errorf("%s: could not create UBIRCH Protocol Package: %v", msg.ID, err)
 		return errorResponse(http.StatusInternalServerError, "")
 	}
-	log.Debugf("%s: UPP: %s", name, hex.EncodeToString(upp))
+
+	return s.sendUPP(msg, upp)
+}
+
+func (s *Signer) getChainedUPP(id uuid.UUID, hash []byte) ([]byte, error) {
+	prevSignature, err := s.protocol.LoadSignature(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.protocol.Sign(
+		&ubirch.ChainedUPP{Version: ubirch.Chained, Uuid: id, PrevSignature: prevSignature, Hint: ubirch.Binary, Payload: hash},
+	)
+}
+
+func (s *Signer) getSignedUPP(id uuid.UUID, hash []byte, op operation) ([]byte, error) {
+	hint, found := hintLookup[op]
+	if !found {
+		return nil, fmt.Errorf("%s: invalid operation: \"%s\"", id, op)
+	}
+
+	return s.protocol.Sign(
+		&ubirch.SignedUPP{Version: ubirch.Signed, Uuid: id, Hint: hint, Payload: hash},
+	)
+}
+
+func (s *Signer) sendUPP(msg HTTPRequest, upp []byte) HTTPResponse {
+	log.Debugf("%s: UPP: %s", msg.ID, hex.EncodeToString(upp))
 
 	// send UPP to ubirch backend
-	backendResp, err := post(s.authServiceURL, upp, ubirchHeader(msg.ID, auth))
+	backendResp, err := post(s.authServiceURL, upp, ubirchHeader(msg.ID, msg.Auth))
 	if err != nil {
-		log.Errorf("%s: sending request to UBIRCH Authentication Service failed: %v", name, err)
+		log.Errorf("%s: sending request to UBIRCH Authentication Service failed: %v", msg.ID, err)
 		return errorResponse(http.StatusInternalServerError, "")
 	}
-	log.Debugf("%s: backend response: (%d) %s", name, backendResp.StatusCode, hex.EncodeToString(backendResp.Content))
+	log.Debugf("%s: backend response: (%d) %s", msg.ID, backendResp.StatusCode, hex.EncodeToString(backendResp.Content))
 
 	// decode the backend response UPP and get request ID
 	var requestID string
@@ -143,35 +162,11 @@ func (s *Signer) handleSigningRequest(msg HTTPRequest) HTTPResponse {
 		if err != nil {
 			log.Warnf("could not get request ID from backend response: %v", err)
 		} else {
-			log.Infof("%s: request ID: %s", name, requestID)
+			log.Infof("%s: request ID: %s", msg.ID, requestID)
 		}
 	}
 
 	return getSigningResponse(backendResp.StatusCode, msg, upp, backendResp, requestID, "")
-}
-
-func (s *Signer) anchorHash(name string, hash []byte) ([]byte, error) {
-	log.Infof("%s: anchoring hash: %s", name, base64.StdEncoding.EncodeToString(hash))
-
-	return s.protocol.SignHash(name, hash, ubirch.Chained)
-}
-
-func (s *Signer) disableHash(name string, hash []byte) ([]byte, error) {
-	log.Infof("%s: disabling hash: %s", name, base64.StdEncoding.EncodeToString(hash))
-
-	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Disable)
-}
-
-func (s *Signer) enableHash(name string, hash []byte) ([]byte, error) {
-	log.Infof("%s: enabling hash: %s", name, base64.StdEncoding.EncodeToString(hash))
-
-	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Enable)
-}
-
-func (s *Signer) deleteHash(name string, hash []byte) ([]byte, error) {
-	log.Infof("%s: deleting hash: %s", name, base64.StdEncoding.EncodeToString(hash))
-
-	return s.protocol.SignHashExtended(name, hash, ubirch.Signed, ubirch.Delete)
 }
 
 func getRequestID(respUPP ubirch.UPP) (string, error) {

--- a/main/verifier.go
+++ b/main/verifier.go
@@ -179,7 +179,7 @@ func (v *Verifier) loadPublicKey(name string, id uuid.UUID) ([]byte, error) {
 		return nil, fmt.Errorf("unable to set retrieved public key for verification: %v", err)
 	}
 
-	err = v.protocol.PersistContext()
+	err = v.protocol.PersistKeys()
 	if err != nil {
 		log.Errorf("unable to persist retrieved public key for UUID %s: %v", name, err)
 	}


### PR DESCRIPTION
**Changed:**

- split up protocol context into key store and signature store
  - encrypted keys are stored in `keys.json` file
  - signatures are stored in individual `<uuid>.bin` files in `signatures` subfolder
  - **backwards compatible**: if present, legacy `protocol.json` file will be transferred into new structure at startup and then removed
- Dockerfile: upgrade to go version 1.16

**Added:**

- load test checks chain
- request buffer size is configurable via `RequestBufferSize` attribute in `config.json`

**Removed:**

- support for managing protocol context in DB has temporarily been removed _(will be fixed soon)_