### PR TITLE
UNG-1761 concurrency

### DIFF
--- a/load-test/helper.go
+++ b/load-test/helper.go
@@ -180,6 +180,6 @@ func countFails(statusCodes <-chan string, cancel context.CancelFunc) {
 	}
 
 	for status, count := range failCounters {
-		log.Errorf("%4d x [ %s ]", count, status)
+		log.Errorf("[ %4d ] x %s", count, status)
 	}
 }

--- a/load-test/helper.go
+++ b/load-test/helper.go
@@ -62,14 +62,51 @@ func getTestIdentities(num int) map[string]string {
 	return testIdentities
 }
 
-func setup() {
+type testCtx struct {
+	ccChan     chan<- []byte
+	ccCtx      context.Context
+	failChan   chan<- string
+	failCtx    context.Context
+	wg         *sync.WaitGroup
+	identities map[string]string
+}
+
+func setup() *testCtx {
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true, TimestampFormat: "2006-01-02 15:04:05.000 -0700"})
 	log.SetLevel(log.DebugLevel)
+
+	ccChan, ccCtx := setupChainChecker()
+	failChan, failCtx := setupFailCounter()
+
+	return &testCtx{
+		ccChan:     ccChan,
+		ccCtx:      ccCtx,
+		failChan:   failChan,
+		failCtx:    failCtx,
+		wg:         &sync.WaitGroup{},
+		identities: getTestIdentities(numberOfTestIDs),
+	}
+}
+
+func (t *testCtx) teardown() {
+	close(t.ccChan)
+	<-t.ccCtx.Done()
+	close(t.failChan)
+	<-t.failCtx.Done()
 }
 
 type chainChecker struct {
 	signatures      map[string][]byte
 	signaturesMutex sync.RWMutex
+}
+
+func setupChainChecker() (chan []byte, context.Context) {
+	cc := chainChecker{signatures: make(map[string][]byte, numberOfTestIDs)}
+	ccChan := make(chan []byte)
+	ctx, cancel := context.WithCancel(context.Background())
+	go cc.checkChain(ccChan, cancel)
+
+	return ccChan, ctx
 }
 
 func (c *chainChecker) checkChain(uppBytes <-chan []byte, cancel context.CancelFunc) {
@@ -119,4 +156,30 @@ func (c *chainChecker) SetSignature(id string, signature []byte) {
 	defer c.signaturesMutex.Unlock()
 
 	c.signatures[id] = signature
+}
+
+func setupFailCounter() (chan string, context.Context) {
+	failChan := make(chan string)
+	ctx, cancel := context.WithCancel(context.Background())
+	go countFails(failChan, cancel)
+
+	return failChan, ctx
+}
+
+func countFails(statusCodes <-chan string, cancel context.CancelFunc) {
+	defer cancel()
+	failCounters := map[string]int{}
+
+	for status := range statusCodes {
+		count, found := failCounters[status]
+		if !found {
+			failCounters[status] = 1
+		} else {
+			failCounters[status] = count + 1
+		}
+	}
+
+	for status, count := range failCounters {
+		log.Errorf("%4d x [ %s ]", count, status)
+	}
 }

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -36,7 +36,8 @@ func main() {
 	start := time.Now()
 
 	for uid, auth := range testIdentities {
-		sendRequests(uid, auth, ccChan, &wg)
+		wg.Add(1)
+		go sendRequests(uid, auth, ccChan, &wg)
 	}
 
 	log.Infof(" = = = => requests sent after %7.3f seconds <= = = = ", time.Since(start).Seconds())
@@ -47,6 +48,8 @@ func main() {
 }
 
 func sendRequests(id string, auth string, ccChan chan<- []byte, wg *sync.WaitGroup) {
+	defer wg.Done()
+
 	HTTPclient := &http.Client{Timeout: 65 * time.Second}
 	clientURL := clientBaseURL + id + "/hash"
 	header := http.Header{}

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -22,7 +22,7 @@ const (
 func main() {
 	t := setup()
 
-	log.Infof("%d identities, %d requests each => sending [%d] requests", len(t.identities), numberOfRequestsPerID, len(t.identities)*numberOfRequestsPerID)
+	log.Infof("%d identities, %d requests each => sending [ %d ] requests", len(t.identities), numberOfRequestsPerID, len(t.identities)*numberOfRequestsPerID)
 	log.Infof("%d requests per second per identity", requestsPerSecondPerID)
 
 	start := time.Now()
@@ -33,14 +33,14 @@ func main() {
 	}
 
 	t.wg.Wait()
-	log.Infof(" = = = => requests done after %7.3f seconds <= = = = ", time.Since(start).Seconds())
+	log.Infof(" = = = => requests done after [ %7.3f ] seconds <= = = = ", time.Since(start).Seconds())
 	t.teardown()
 }
 
 func (t *testCtx) sendRequests(id string, auth string) {
 	defer t.wg.Done()
 
-	HTTPclient := &http.Client{Timeout: 65 * time.Second}
+	HTTPclient := &http.Client{Timeout: 30 * time.Second}
 	clientURL := clientBaseURL + id + "/hash"
 	header := http.Header{}
 	header.Set("Content-Type", "application/octet-stream")

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -16,8 +16,9 @@ import (
 const (
 	clientBaseURL         = "http://localhost:8080/"
 	configFile            = "config.json"
-	numberOfTestIDs       = 100
-	numberOfRequestsPerID = 4
+	numberOfTestIDs       = 50
+	numberOfRequestsPerID = 10
+	requestsPerSecond     = 5
 )
 
 func main() {
@@ -27,6 +28,7 @@ func main() {
 	testIdentities := getTestIdentities(numberOfTestIDs)
 	log.Infof("%d identities, %d requests each", len(testIdentities), numberOfRequestsPerID)
 	log.Infof(" = = = => sending %d requests <= = = = ", len(testIdentities)*numberOfRequestsPerID)
+	log.Infof(" = = = => %d requests per second <= = = = ", requestsPerSecond)
 
 	cc := chainChecker{signatures: make(map[string][]byte, numberOfTestIDs)}
 	ccChan := make(chan []byte)
@@ -60,7 +62,7 @@ func sendRequests(id string, auth string, ccChan chan<- []byte, wg *sync.WaitGro
 		wg.Add(1)
 		go sendAndCheckResponse(HTTPclient, clientURL, header, ccChan, wg)
 
-		time.Sleep(time.Second / numberOfRequestsPerID)
+		time.Sleep(time.Second / requestsPerSecond)
 	}
 }
 

--- a/load-test/main.go
+++ b/load-test/main.go
@@ -14,22 +14,26 @@ import (
 const (
 	clientBaseURL          = "http://localhost:8080/"
 	configFile             = "config.json"
-	numberOfTestIDs        = 100
-	numberOfRequestsPerID  = 10
-	requestsPerSecondPerID = 4
+	numberOfTestIDs        = 500
+	numberOfRequestsPerID  = 2
+	IDsPerSecond           = 5
+	requestsPerSecondPerID = 2
 )
 
 func main() {
 	t := setup()
 
 	log.Infof("%d identities, %d requests each => sending [ %d ] requests", len(t.identities), numberOfRequestsPerID, len(t.identities)*numberOfRequestsPerID)
-	log.Infof("%d requests per second per identity", requestsPerSecondPerID)
+	log.Infof("%3d requests per second per identity", requestsPerSecondPerID)
+	log.Infof("%3d requests per second overall", requestsPerSecondPerID*IDsPerSecond)
 
 	start := time.Now()
 
 	for uid, auth := range t.identities {
 		t.wg.Add(1)
 		go t.sendRequests(uid, auth)
+
+		time.Sleep(time.Second / IDsPerSecond)
 	}
 
 	t.wg.Wait()

--- a/main/client.go
+++ b/main/client.go
@@ -88,10 +88,10 @@ func ubirchHeader(uid uuid.UUID, auth string) map[string]string {
 
 // post submits a message to a backend service
 // returns the response or encountered errors
-func post(url string, data []byte, header map[string]string) (HTTPResponse, error) {
+func post(serviceURL string, data []byte, header map[string]string) (HTTPResponse, error) {
 	client := &http.Client{Timeout: BackendRequestTimeout}
 
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
+	req, err := http.NewRequest(http.MethodPost, serviceURL, bytes.NewBuffer(data))
 	if err != nil {
 		return HTTPResponse{}, fmt.Errorf("can't make new post request: %v", err)
 	}
@@ -109,11 +109,15 @@ func post(url string, data []byte, header map[string]string) (HTTPResponse, erro
 	defer resp.Body.Close()
 
 	respBodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return HTTPResponse{}, err
+	}
+
 	return HTTPResponse{
 		StatusCode: resp.StatusCode,
 		Header:     resp.Header,
 		Content:    respBodyBytes,
-	}, err
+	}, nil
 }
 
 // requestPublicKeys requests a devices public keys at the identity service

--- a/main/config.go
+++ b/main/config.go
@@ -274,10 +274,10 @@ func (c *Config) setDefaultURLs() error {
 	}
 
 	log.Infof("UBIRCH backend environment: %s", c.Env)
-	log.Debugf(" - Key Service:            %s", c.KeyService)
-	log.Debugf(" - Identity Service:       %s", c.IdentityService)
-	log.Debugf(" - Authentication Service: %s", c.Niomon)
-	log.Debugf(" - Verification Service:   %s", c.VerifyService)
+	log.Infof(" - Key Service:            %s", c.KeyService)
+	log.Infof(" - Identity Service:       %s", c.IdentityService)
+	log.Infof(" - Authentication Service: %s", c.Niomon)
+	log.Infof(" - Verification Service:   %s", c.VerifyService)
 
 	return nil
 }

--- a/main/config.go
+++ b/main/config.go
@@ -46,7 +46,7 @@ const (
 	defaultTLSCertFile = "cert.pem"
 	defaultTLSKeyFile  = "key.pem"
 
-	defaultReqBufSize = 30
+	defaultReqBufSize = 20 // expected max. waiting time for accepted requests at a throughput of 3rps => ~7sec
 )
 
 var ENV string

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -18,9 +18,9 @@ const (
 	BackendRequestTimeout = 10 * time.Second // time after which requests to the ubirch backend will be canceled
 	GatewayTimeout        = 20 * time.Second // time after which the client sends a 504 response if no timely response could be produced
 	ShutdownTimeout       = 25 * time.Second // time after which the server will be shut down forcefully if graceful shutdown did not happen before
-	ReadTimeout           = 1 * time.Second
-	WriteTimeout          = 30 * time.Second
-	IdleTimeout           = 60 * time.Second
+	ReadTimeout           = 1 * time.Second  // maximum duration for reading the entire request -> low since we only expect requests with small content
+	WriteTimeout          = 30 * time.Second // time after which the connection will be closed if response was not written -> this should never happen
+	IdleTimeout           = 60 * time.Second // time to wait for the next request when keep-alives are enabled
 )
 
 type ServerEndpoint struct {

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -15,12 +15,12 @@ import (
 )
 
 const (
+	BackendRequestTimeout = 15 * time.Second // time after which requests to the ubirch backend will be canceled
 	GatewayTimeout        = 20 * time.Second // time after which the client sends a 504 response if no timely response could be produced
 	ShutdownTimeout       = 25 * time.Second // time after which the server will be shut down forcefully if graceful shutdown did not happen before
-	BackendRequestTimeout = 15 * time.Second // time after which requests to the ubirch backend will be canceled
-	ReadTimeout           = 5 * time.Second
+	ReadTimeout           = 1 * time.Second
 	WriteTimeout          = 30 * time.Second
-	IdleTimeout           = 120 * time.Second
+	IdleTimeout           = 60 * time.Second
 )
 
 type ServerEndpoint struct {

--- a/main/http_server.go
+++ b/main/http_server.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	BackendRequestTimeout = 15 * time.Second // time after which requests to the ubirch backend will be canceled
+	BackendRequestTimeout = 10 * time.Second // time after which requests to the ubirch backend will be canceled
 	GatewayTimeout        = 20 * time.Second // time after which the client sends a 504 response if no timely response could be produced
 	ShutdownTimeout       = 25 * time.Second // time after which the server will be shut down forcefully if graceful shutdown did not happen before
 	ReadTimeout           = 1 * time.Second

--- a/main/key_handler.go
+++ b/main/key_handler.go
@@ -31,6 +31,7 @@ func initDeviceKeys(p *ExtendedProtocol, conf Config) error {
 	}
 
 	// create and register keys for identities
+	log.Infof("initializing %d identities...", len(conf.Devices))
 	for name, auth := range conf.Devices {
 		// make sure identity name is a valid UUID
 		uid, err := uuid.Parse(name)
@@ -150,7 +151,7 @@ func registerPublicKey(p *ExtendedProtocol, uid uuid.UUID, pubKey []byte, keySer
 
 // submitCSR submits a X.509 Certificate Signing Request for the public key to the identity service
 func submitCSR(p *ExtendedProtocol, uid uuid.UUID, subjectCountry string, subjectOrganization string, identityService string) error {
-	log.Printf("%s: submitting CSR to identity service: %s", uid, identityService)
+	log.Debugf("%s: submitting CSR to identity service", uid)
 
 	csr, err := p.GetCSR(uid, subjectCountry, subjectOrganization)
 	if err != nil {

--- a/main/services.go
+++ b/main/services.go
@@ -50,7 +50,7 @@ type HTTPResponse struct {
 }
 
 type ChainingService struct {
-	Jobs       chan ChainingRequest
+	Jobs       map[string]chan ChainingRequest
 	AuthTokens map[string]string
 }
 
@@ -137,7 +137,7 @@ func (c *ChainingService) handleRequest(w http.ResponseWriter, r *http.Request) 
 
 func (c *ChainingService) submitForChaining(msg ChainingRequest) error {
 	select {
-	case c.Jobs <- msg:
+	case c.Jobs[msg.ID.String()] <- msg:
 		return nil
 	default: // do not accept any more requests if buffer is full
 		return fmt.Errorf("resquest skipped due to overflowing request channel")

--- a/main/signer.go
+++ b/main/signer.go
@@ -151,8 +151,7 @@ func (s *Signer) getChainedUPP(id uuid.UUID, hash [32]byte) ([]byte, error) {
 			PrevSignature: prevSignature,
 			Hint:          ubirch.Binary,
 			Payload:       hash[:],
-		},
-	)
+		})
 }
 
 func (s *Signer) getSignedUPP(id uuid.UUID, hash [32]byte, op operation) ([]byte, error) {
@@ -167,8 +166,7 @@ func (s *Signer) getSignedUPP(id uuid.UUID, hash [32]byte, op operation) ([]byte
 			Uuid:    id,
 			Hint:    hint,
 			Payload: hash[:],
-		},
-	)
+		})
 }
 
 func (s *Signer) sendUPP(msg HTTPRequest, upp []byte) HTTPResponse {

--- a/main/signer.go
+++ b/main/signer.go
@@ -115,8 +115,6 @@ func (s *Signer) chainer(chainerID string, jobs <-chan ChainingRequest) error {
 					err, msg.ID, base64.StdEncoding.EncodeToString(signature))
 				return err
 			}
-		} else {
-			log.Errorf("%s: [chain] request failed: (%d) %s", msg.ID, resp.StatusCode, string(resp.Content))
 		}
 	}
 
@@ -135,10 +133,6 @@ func (s *Signer) Sign(msg SigningRequest) HTTPResponse {
 	log.Debugf("%s: signed UPP: %x", msg.ID, uppBytes)
 
 	resp := s.sendUPP(msg.HTTPRequest, uppBytes)
-
-	if httpFailed(resp.StatusCode) {
-		log.Errorf("%s: [%s] request failed: (%d) %s", msg.ID, msg.Operation, resp.StatusCode, string(resp.Content))
-	}
 
 	return resp
 }
@@ -236,6 +230,10 @@ func getSigningResponse(respCode int, msg HTTPRequest, upp []byte, backendResp H
 	})
 	if err != nil {
 		log.Warnf("error serializing signing response: %v", err)
+	}
+
+	if httpFailed(respCode) {
+		log.Errorf("%s: request failed: (%d) %s", msg.ID, respCode, string(signingResp))
 	}
 
 	return HTTPResponse{

--- a/main/signer.go
+++ b/main/signer.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
+	"os"
 
 	"github.com/google/uuid"
 	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
@@ -175,8 +175,8 @@ func (s *Signer) sendUPP(msg HTTPRequest, upp []byte) HTTPResponse {
 	// send UPP to ubirch backend
 	backendResp, err := post(s.authServiceURL, upp, ubirchHeader(msg.ID, msg.Auth))
 	if err != nil {
-		if e, ok := err.(*url.Error); ok && e.Timeout() {
-			log.Errorf("%s: request to UBIRCH Authentication Service timed out after %d sec: %v", msg.ID, BackendRequestTimeout, err)
+		if os.IsTimeout(err) {
+			log.Errorf("%s: request to UBIRCH Authentication Service timed out after %s: %v", msg.ID, BackendRequestTimeout.String(), err)
 			return errorResponse(http.StatusGatewayTimeout, "")
 		} else {
 			log.Errorf("%s: sending request to UBIRCH Authentication Service failed: %v", msg.ID, err)


### PR DESCRIPTION
**Changed:**
- concurrent handling of chaining requests between multiple identities
  > Chaining is still handled synchronous for each identity, meaning that the concurrency only increases throughput of requests from multiple identities. The throughput for chaining is still at about 3rps for each individual identity.
- explicit error response for backend request timeout: "gateway timeout"
- reduced default request buffer size to 20 in order to keep expected max. waiting time for accepted requests under 10 sec (calculated with worst case throughput of 2 rps)
- reduced backend request timeout to 10 sec to ensure response within gateway timeout of 20 sec
- reduced read timeout to 1 sec since we only expect requests with small content
- only log CSR submission in debug mode (cleaner log)

**Added:**
- load test: 
  - test concurrent requests from multiple devices
  - test overall throughput
  - count failed requests and print summary
