### PR TITLE
UNG-2257 send csr in registration response

### DIFF
--- a/main/adapters/handlers/aa.go
+++ b/main/adapters/handlers/aa.go
@@ -7,6 +7,6 @@ import (
 
 type FetchIdentity func(uid uuid.UUID) (*ent.Identity, error)
 
-type StoreIdentity func(uid uuid.UUID, auth string) error
+type StoreIdentity func(uid uuid.UUID, auth string) (csr []byte, err error)
 
 type CheckIdentityExists func(uid uuid.UUID) (bool, error)

--- a/main/adapters/handlers/identity.go
+++ b/main/adapters/handlers/identity.go
@@ -58,14 +58,19 @@ func (i *Identity) Put(storeId StoreIdentity, idExists CheckIdentityExists) http
 			return
 		}
 
-		err = storeId(uid, idPayload.Pwd)
+		csr, err := storeId(uid, idPayload.Pwd)
 		if err != nil {
 			log.Errorf("%s: %v", uid, err)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 
-		h.Ok(w, fmt.Sprintf("successfully created new entry with uuid %s\n", uid))
+		w.Header().Set(h.HeaderContentType, vars.BinType)
+		w.WriteHeader(http.StatusOK)
+		_, err = w.Write(csr)
+		if err != nil {
+			log.Errorf("unable to write response: %s", err)
+		}
 	}
 }
 

--- a/main/uc/identity.go
+++ b/main/uc/identity.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NewIdentityStorer(idHandler *handlers.IdentityHandler) handlers.StoreIdentity {
-	return func(uid uuid.UUID, auth string) error {
+	return func(uid uuid.UUID, auth string) (csr []byte, err error) {
 		return idHandler.InitIdentity(uid, auth)
 	}
 }


### PR DESCRIPTION
**Changed:**

- when a new identity is registered via the registration endpoint, the HTTP response body now contains the DER-encoded x.509 CSR in case the registration was successful