### PR TITLE
Fix injecting tagged version during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ REVISION = $(shell git rev-parse --short HEAD)$(shell if ! git diff --no-ext-dif
 CURRENT_BRANCH = $(shell git branch --show-current |tr -cd '[:alnum:]-.')
 
 NAME := ubirch-client
-SRC_URL = https://gitlab.com/ubirch/ubirch-client-go.git
+SRC_URL = https://github.com/ubirch/ubirch-client-go.git
 IMAGE_REPO := docker.io/ubirch/$(NAME)
 IMAGE_TAG := $(VERSION)
 IMAGE_ARCHS := amd64 arm arm64 386 # supported architectures

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 
 NOW = $(shell date -u -Iminutes)
 VERSION = $(shell git describe --tags --match 'v[0-9]*' --dirty='-dirty' --always)
-REVISION = $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo -dirty; fi)
+REVISION = $(shell git rev-parse --short HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo -dirty; fi)
 CURRENT_BRANCH = $(shell git branch --show-current |tr -cd '[:alnum:]-.')
 
 NAME := ubirch-client
@@ -70,7 +70,7 @@ test:
 image:
 	$(DOCKER) build -t $(IMAGE_REPO):$(IMAGE_TAG) \
 		--build-arg="VERSION=$(VERSION)" \
-		--build-arg="REVISION=$(VERSION)" \
+		--build-arg="REVISION=$(REVISION)" \
 		--build-arg="GOVERSION=$(GO_VERSION)" \
 		--label="org.opencontainers.image.title=$(NAME)" \
 		--label="org.opencontainers.image.created=$(NOW)" \
@@ -91,7 +91,7 @@ publish:
 		$(DOCKER) build -t "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" \
 			--build-arg="GOARCH=$${arch}" \
 			--build-arg="VERSION=$(VERSION)" \
-			--build-arg="REVISION=$(VERSION)" \
+			--build-arg="REVISION=$(REVISION)" \
 			--build-arg="GOVERSION=$(GO_VERSION)" \
 			--label="org.opencontainers.image.title=$(NAME)" \
 			--label="org.opencontainers.image.created=$(NOW)" \

--- a/main/Makefile
+++ b/main/Makefile
@@ -29,7 +29,7 @@
 
 NOW = $(shell date -u -Iminutes)
 VERSION = $(shell git describe --tags --match 'v[0-9]*' --dirty='-dirty' --always)
-REVISION = $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo -dirty; fi)
+REVISION = $(shell git rev-parse --short HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo -dirty; fi)
 CURRENT_BRANCH = $(shell git branch --show-current |tr -cd '[:alnum:]-.')
 
 NAME := ubirch-client

--- a/main/main.go
+++ b/main/main.go
@@ -50,15 +50,19 @@ func shutdown(cancel context.CancelFunc) {
 
 var (
 	// Version will be replaced with the tagged version during build time
-	Version = "unreleased"
+	Version = "local build"
 	// Revision will be replaced with the commit hash during build time
 	Revision = "unknown"
 )
 
 func main() {
-	var configDir string
-	migrate := false
-	initIdentities := false
+	const configFile = "config.json"
+
+	var (
+		configDir      string
+		migrate        bool
+		initIdentities bool
+	)
 
 	if len(os.Args) > 1 {
 		for i, arg := range os.Args[1:] {
@@ -74,11 +78,10 @@ func main() {
 	}
 
 	log.SetFormatter(&log.JSONFormatter{})
-	log.Printf("UBIRCH client (%s, revision=%s)", Version, Revision)
+	log.Printf("UBIRCH client (version=%s, revision=%s)", Version, Revision)
 
 	// read configuration
 	conf := config.Config{}
-	const configFile = "config.json"
 	err := conf.Load(configDir, configFile)
 	if err != nil {
 		log.Fatalf("ERROR: unable to load configuration: %s", err)

--- a/main/main.go
+++ b/main/main.go
@@ -48,13 +48,14 @@ func shutdown(cancel context.CancelFunc) {
 	cancel()
 }
 
-func main() {
-	const (
-		Version    = "v2.0.0"
-		Build      = "local"
-		configFile = "config.json"
-	)
+var (
+	// Version will be replaced with the tagged version during build time
+	Version    = "unreleased"
+	// Build will be replaced with the commit hash during build time
+	Build      = "local"
+)
 
+func main() {
 	var configDir string
 	migrate := false
 	initIdentities := false
@@ -77,6 +78,7 @@ func main() {
 
 	// read configuration
 	conf := config.Config{}
+	const configFile = "config.json"
 	err := conf.Load(configDir, configFile)
 	if err != nil {
 		log.Fatalf("ERROR: unable to load configuration: %s", err)

--- a/main/main.go
+++ b/main/main.go
@@ -50,9 +50,9 @@ func shutdown(cancel context.CancelFunc) {
 
 var (
 	// Version will be replaced with the tagged version during build time
-	Version    = "unreleased"
-	// Build will be replaced with the commit hash during build time
-	Build      = "local"
+	Version = "unreleased"
+	// Revision will be replaced with the commit hash during build time
+	Revision = "unknown"
 )
 
 func main() {
@@ -74,7 +74,7 @@ func main() {
 	}
 
 	log.SetFormatter(&log.JSONFormatter{})
-	log.Printf("UBIRCH client (%s, build=%s)", Version, Build)
+	log.Printf("UBIRCH client (%s, revision=%s)", Version, Revision)
 
 	// read configuration
 	conf := config.Config{}


### PR DESCRIPTION
The Version and Build Variables were designed to be replaced during the linking step on build time. This pull request implements this behaviour, fixing the problems that keep it from working as intended.

This can be tested by running the `make image` target.

![image](https://user-images.githubusercontent.com/33927916/118162960-a92ab180-b421-11eb-951d-397795a05a43.png)

output when running:

![image](https://user-images.githubusercontent.com/33927916/118163514-5bfb0f80-b422-11eb-8c81-8a795b53429d.png)