### PR TITLE
Enhance reusability

### DIFF
--- a/main/adapters/handlers/identity.go
+++ b/main/adapters/handlers/identity.go
@@ -60,7 +60,7 @@ func (i *IdentityCreator) Put(storeId StoreIdentity, idExists CheckIdentityExist
 			return
 		}
 
-		timer := prometheus.NewTimer(p.IdentityCreation)
+		timer := prometheus.NewTimer(p.IdentityCreationDuration)
 		csr, err := storeId(uid, idPayload.Pwd)
 		timer.ObserveDuration()
 		if err != nil {

--- a/main/adapters/handlers/identity.go
+++ b/main/adapters/handlers/identity.go
@@ -12,8 +12,8 @@ import (
 	"net/http"
 )
 
-type Identity struct {
-	globals Globals
+type IdentityCreator struct {
+	auth string
 }
 
 type IdentityPayload struct {
@@ -21,14 +21,14 @@ type IdentityPayload struct {
 	Pwd string `json:"password"`
 }
 
-func NewIdentity(globals Globals) Identity {
-	return Identity{globals: globals}
+func NewIdentityCreator(auth string) IdentityCreator {
+	return IdentityCreator{auth: auth}
 }
 
-func (i *Identity) Put(storeId StoreIdentity, idExists CheckIdentityExists) http.HandlerFunc {
+func (i *IdentityCreator) Put(storeId StoreIdentity, idExists CheckIdentityExists) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get(h.XAuthHeader)
-		if authHeader != i.globals.Config.RegisterAuth {
+		if authHeader != i.auth {
 			log.Warnf("unauthorized registration attempt")
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return

--- a/main/adapters/handlers/identity.go
+++ b/main/adapters/handlers/identity.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -69,9 +70,11 @@ func (i *IdentityCreator) Put(storeId StoreIdentity, idExists CheckIdentityExist
 			return
 		}
 
+		csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csr})
+
 		w.Header().Set(h.HeaderContentType, vars.BinType)
 		w.WriteHeader(http.StatusOK)
-		_, err = w.Write(csr)
+		_, err = w.Write(csrPEM)
 		if err != nil {
 			log.Errorf("unable to write response: %s", err)
 		}

--- a/main/adapters/handlers/signer.go
+++ b/main/adapters/handlers/signer.go
@@ -175,7 +175,7 @@ func (s *Signer) getSignedUPP(id uuid.UUID, hash [32]byte, privateKeyPEM []byte,
 
 func (s *Signer) sendUPP(msg HTTPRequest, upp []byte) h.HTTPResponse {
 	// send UPP to ubirch backend
-	timer := prometheus.NewTimer(p.BackendResponseDuration)
+	timer := prometheus.NewTimer(p.UpstreamResponseDuration)
 	backendResp, err := s.Protocol.SendToAuthService(msg.ID, msg.Auth, upp)
 	timer.ObserveDuration()
 	if err != nil {

--- a/main/adapters/handlers/signer.go
+++ b/main/adapters/handlers/signer.go
@@ -175,7 +175,7 @@ func (s *Signer) getSignedUPP(id uuid.UUID, hash [32]byte, privateKeyPEM []byte,
 
 func (s *Signer) sendUPP(msg HTTPRequest, upp []byte) h.HTTPResponse {
 	// send UPP to ubirch backend
-	timer := prometheus.NewTimer(p.NiomonResponseDuration)
+	timer := prometheus.NewTimer(p.BackendResponseDuration)
 	backendResp, err := s.Protocol.SendToAuthService(msg.ID, msg.Auth, upp)
 	timer.ObserveDuration()
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -183,8 +183,8 @@ func main() {
 	}
 
 	// set up endpoint for identity registration
-	identity := createIdentityUseCases(globals, idHandler)
-	httpServer.Router.Put(fmt.Sprintf("/%s",vars.RegisterEndpoint), identity.handler.Put(identity.storeIdentity, identity.checkIdentity))
+	identity := createIdentityUseCases(globals.Config.RegisterAuth, idHandler)
+	httpServer.Router.Put(fmt.Sprintf("/%s", vars.RegisterEndpoint), identity.handler.Put(identity.storeIdentity, identity.checkIdentity))
 
 	// set up endpoint for chaining
 	httpServer.AddServiceEndpoint(handlers.ServerEndpoint{
@@ -223,15 +223,15 @@ func main() {
 }
 
 type identities struct {
-	handler       handlers.Identity
+	handler       handlers.IdentityCreator
 	storeIdentity handlers.StoreIdentity
 	fetchIdentity handlers.FetchIdentity
 	checkIdentity handlers.CheckIdentityExists
 }
 
-func createIdentityUseCases(globals handlers.Globals, handler *handlers.IdentityHandler) identities {
+func createIdentityUseCases(auth string, handler *handlers.IdentityHandler) identities {
 	return identities{
-		handler:       handlers.NewIdentity(globals),
+		handler:       handlers.NewIdentityCreator(auth),
 		storeIdentity: uc.NewIdentityStorer(handler),
 		fetchIdentity: uc.NewIdentityFetcher(handler),
 		checkIdentity: uc.NewIdentityChecker(handler),

--- a/main/prometheus/prom.go
+++ b/main/prometheus/prom.go
@@ -48,9 +48,9 @@ var httpDuration = promauto.NewHistogramVec(
 	[]string{"path"},
 )
 
-var NiomonResponseDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-	Name:    "niomon_response_duration",
-	Help:    "Duration of HTTP responses from niomon.",
+var BackendResponseDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name:    "backend_response_duration",
+	Help:    "Duration of HTTP responses from the backend (upstream server).",
 	Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
 })
 
@@ -80,7 +80,7 @@ func RegisterPromMetrics() {
 	prometheus.Register(totalRequests)
 	prometheus.Register(responseStatus)
 	prometheus.Register(httpDuration)
-	prometheus.Register(NiomonResponseDuration)
+	prometheus.Register(BackendResponseDuration)
 	prometheus.Register(SignatureCreationDuration)
 	prometheus.Register(SignatureCreationCounter)
 	prometheus.Register(IdentityCreationDuration)

--- a/main/prometheus/prom.go
+++ b/main/prometheus/prom.go
@@ -48,9 +48,9 @@ var httpDuration = promauto.NewHistogramVec(
 	[]string{"path"},
 )
 
-var BackendResponseDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
-	Name:    "backend_response_duration",
-	Help:    "Duration of HTTP responses from the backend (upstream server).",
+var UpstreamResponseDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+	Name:    "upstream_response_duration",
+	Help:    "Duration of HTTP responses from upstream server.",
 	Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
 })
 
@@ -80,7 +80,7 @@ func RegisterPromMetrics() {
 	prometheus.Register(totalRequests)
 	prometheus.Register(responseStatus)
 	prometheus.Register(httpDuration)
-	prometheus.Register(BackendResponseDuration)
+	prometheus.Register(UpstreamResponseDuration)
 	prometheus.Register(SignatureCreationDuration)
 	prometheus.Register(SignatureCreationCounter)
 	prometheus.Register(IdentityCreationDuration)

--- a/main/prometheus/prom.go
+++ b/main/prometheus/prom.go
@@ -54,15 +54,26 @@ var NiomonResponseDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
 	Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
 })
 
-var IdentityCreation = promauto.NewHistogram(prometheus.HistogramOpts{
+var SignatureCreationDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+	Name:    "signature_creation_duration",
+	Help:    "Duration of the creation of a signed object",
+	Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
+})
+
+var SignatureCreationCounter = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "signature_creation_success",
+	Help: "Number of successfully created signatures",
+})
+
+var IdentityCreationDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 	Name:    "identity_creation_duration",
-	Help:    "Duration of the identity being created, stored and registered.",
+	Help:    "Duration of the identity being created, registered and stored.",
 	Buckets: prometheus.LinearBuckets(0.01, 0.01, 10),
 })
 
 var IdentityCreationCounter = prometheus.NewCounter(prometheus.CounterOpts{
 	Name: "identity_creation_success",
-	Help: "Number of identities which have been successfully created and stored in the db.",
+	Help: "Number of identities which have been successfully created and stored.",
 })
 
 func RegisterPromMetrics() {
@@ -70,7 +81,9 @@ func RegisterPromMetrics() {
 	prometheus.Register(responseStatus)
 	prometheus.Register(httpDuration)
 	prometheus.Register(NiomonResponseDuration)
-	prometheus.Register(IdentityCreation)
+	prometheus.Register(SignatureCreationDuration)
+	prometheus.Register(SignatureCreationCounter)
+	prometheus.Register(IdentityCreationDuration)
 	prometheus.Register(IdentityCreationCounter)
 }
 


### PR DESCRIPTION
**Added:**

- metrics for signature creation

**Changed:**

- renamed metrics for more general usage
- identity creation response contains PEM formatted CSR
- identity creator constructor only expects auth token as string, instead of typed config struct, for re-usability purpose