### PR TITLE
UNG-2440 enable TLS DB connections

### DIFF
--- a/main/adapters/repository/context_manager.go
+++ b/main/adapters/repository/context_manager.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/ubirch/ubirch-client-go/main/config"
 	"github.com/ubirch/ubirch-client-go/main/ent"
+	"github.com/ubirch/ubirch-client-go/main/vars"
 )
 
 const (
@@ -36,10 +37,10 @@ type ContextManager interface {
 }
 
 func GetCtxManager(c config.Config) (ContextManager, error) {
-	if c.DsnInitContainer {
-		return NewSqlDatabaseInfo(c)
+	if c.PostgresDSN != "" {
+		return NewSqlDatabaseInfo(c.PostgresDSN, vars.PostgreSqlIdentityTableName)
 	} else {
 		return nil, fmt.Errorf("file-based context management is not supported in the current version. " +
-			"Please set DSN parameters in the configuration and conntect to a database or downgrade to a version < 2.0.0")
+			"Please set a postgres DSN in the configuration and conntect to a database or downgrade to a version < 2.0.0")
 	}
 }

--- a/main/adapters/repository/database.go
+++ b/main/adapters/repository/database.go
@@ -76,7 +76,11 @@ func NewSqlDatabaseInfo(dataSourceName, tableName string) (*DatabaseManager, err
 func (dm *DatabaseManager) Exists(uid uuid.UUID) (bool, error) {
 	var id string
 
-	err := dm.db.QueryRow("SELECT uid FROM $1 WHERE uid = $2", dm.tableName, uid.String()).
+	query := fmt.Sprintf(
+		"SELECT uid FROM %s WHERE uid = $1",
+		dm.tableName)
+
+	err := dm.db.QueryRow(query, uid.String()).
 		Scan(&id)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
@@ -95,7 +99,11 @@ func (dm *DatabaseManager) Exists(uid uuid.UUID) (bool, error) {
 func (dm *DatabaseManager) GetPrivateKey(uid uuid.UUID) ([]byte, error) {
 	var privateKey []byte
 
-	err := dm.db.QueryRow("SELECT private_key FROM $1 WHERE uid = $2", dm.tableName, uid.String()).
+	query := fmt.Sprintf(
+		"SELECT private_key FROM %s WHERE uid = $1",
+		dm.tableName)
+
+	err := dm.db.QueryRow(query, uid.String()).
 		Scan(&privateKey)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
@@ -110,7 +118,11 @@ func (dm *DatabaseManager) GetPrivateKey(uid uuid.UUID) ([]byte, error) {
 func (dm *DatabaseManager) GetPublicKey(uid uuid.UUID) ([]byte, error) {
 	var publicKey []byte
 
-	err := dm.db.QueryRow("SELECT public_key FROM $1 WHERE uid = $2", dm.tableName, uid.String()).
+	query := fmt.Sprintf(
+		"SELECT public_key FROM %s WHERE uid = $1",
+		dm.tableName)
+
+	err := dm.db.QueryRow(query, uid.String()).
 		Scan(&publicKey)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
@@ -125,7 +137,11 @@ func (dm *DatabaseManager) GetPublicKey(uid uuid.UUID) ([]byte, error) {
 func (dm *DatabaseManager) GetAuthToken(uid uuid.UUID) (string, error) {
 	var authToken string
 
-	err := dm.db.QueryRow("SELECT auth_token FROM $1 WHERE uid = $2", dm.tableName, uid.String()).
+	query := fmt.Sprintf(
+		"SELECT auth_token FROM %s WHERE uid = $1",
+		dm.tableName)
+
+	err := dm.db.QueryRow(query, uid.String()).
 		Scan(&authToken)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
@@ -151,8 +167,12 @@ func (dm *DatabaseManager) StartTransactionWithLock(ctx context.Context, uid uui
 
 	var id string
 
+	query := fmt.Sprintf(
+		"SELECT uid FROM %s WHERE uid = $1 FOR UPDATE",
+		dm.tableName)
+
 	// lock row FOR UPDATE
-	err = tx.QueryRow("SELECT uid FROM $1 WHERE uid = $2 FOR UPDATE", dm.tableName, uid.String()).
+	err = tx.QueryRow(query, uid).
 		Scan(&id)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
@@ -185,7 +205,11 @@ func (dm *DatabaseManager) FetchIdentity(transactionCtx interface{}, uid uuid.UU
 
 	var id ent.Identity
 
-	err := tx.QueryRow("SELECT * FROM $1 WHERE uid = $2", dm.tableName, uid.String()).
+	query := fmt.Sprintf(
+		"SELECT * FROM %s WHERE uid = $1",
+		dm.tableName)
+
+	err := tx.QueryRow(query, uid.String()).
 		Scan(&id.Uid, &id.PrivateKey, &id.PublicKey, &id.Signature, &id.AuthToken)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
@@ -203,9 +227,13 @@ func (dm *DatabaseManager) SetSignature(transactionCtx interface{}, uid uuid.UUI
 		return fmt.Errorf("transactionCtx for database manager is not of expected type *sql.Tx")
 	}
 
+	query := fmt.Sprintf(
+		"UPDATE %s SET signature = $1 WHERE uid = $2;",
+		dm.tableName)
+
 	_, err := tx.Exec(
-		"UPDATE $1 SET signature = $2 WHERE uid = $3;",
-		dm.tableName, &signature, uid.String())
+		query,
+		&signature, uid.String())
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.SetSignature(tx, uid, signature)
@@ -225,7 +253,11 @@ func (dm *DatabaseManager) StoreNewIdentity(transactionCtx interface{}, identity
 	// make sure identity does not exist yet
 	var id string
 
-	err := tx.QueryRow("SELECT uid FROM $1 WHERE uid = $2 FOR UPDATE", dm.tableName, identity.Uid).
+	query := fmt.Sprintf(
+		"SELECT uid FROM %s WHERE uid = $1 FOR UPDATE;",
+		dm.tableName)
+
+	err := tx.QueryRow(query, identity.Uid).
 		Scan(&id)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
@@ -243,9 +275,11 @@ func (dm *DatabaseManager) StoreNewIdentity(transactionCtx interface{}, identity
 }
 
 func (dm *DatabaseManager) storeIdentity(tx *sql.Tx, identity *ent.Identity) error {
-	_, err := tx.Exec(
-		"INSERT INTO $1 (uid, private_key, public_key, signature, auth_token) VALUES ($2, $3, $4, $5, $6);",
-		dm.tableName, &identity.Uid, &identity.PrivateKey, &identity.PublicKey, &identity.Signature, &identity.AuthToken)
+	query := fmt.Sprintf(
+		"INSERT INTO %s (uid, private_key, public_key, signature, auth_token) VALUES ($1, $2, $3, $4, $5);",
+		dm.tableName)
+
+	_, err := tx.Exec(query, &identity.Uid, &identity.PrivateKey, &identity.PublicKey, &identity.Signature, &identity.AuthToken)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.storeIdentity(tx, identity)

--- a/main/adapters/repository/database.go
+++ b/main/adapters/repository/database.go
@@ -233,14 +233,13 @@ func (dm *DatabaseManager) StoreNewIdentity(transactionCtx interface{}, identity
 		}
 		if err == sql.ErrNoRows {
 			// there were no rows, but otherwise no error occurred
+			return dm.storeIdentity(tx, identity)
 		} else {
 			return err
 		}
 	} else {
 		return ErrExists
 	}
-
-	return dm.storeIdentity(tx, identity)
 }
 
 func (dm *DatabaseManager) storeIdentity(tx *sql.Tx, identity *ent.Identity) error {

--- a/main/adapters/repository/database.go
+++ b/main/adapters/repository/database.go
@@ -76,12 +76,9 @@ func NewSqlDatabaseInfo(dataSourceName, tableName string) (*DatabaseManager, err
 func (dm *DatabaseManager) Exists(uid uuid.UUID) (bool, error) {
 	var id string
 
-	query := fmt.Sprintf(
-		"SELECT uid FROM %s WHERE uid = $1",
-		dm.tableName)
+	query := fmt.Sprintf("SELECT uid FROM %s WHERE uid = $1", dm.tableName)
 
-	err := dm.db.QueryRow(query, uid.String()).
-		Scan(&id)
+	err := dm.db.QueryRow(query, uid.String()).Scan(&id)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.Exists(uid)
@@ -99,12 +96,9 @@ func (dm *DatabaseManager) Exists(uid uuid.UUID) (bool, error) {
 func (dm *DatabaseManager) GetPrivateKey(uid uuid.UUID) ([]byte, error) {
 	var privateKey []byte
 
-	query := fmt.Sprintf(
-		"SELECT private_key FROM %s WHERE uid = $1",
-		dm.tableName)
+	query := fmt.Sprintf("SELECT private_key FROM %s WHERE uid = $1", dm.tableName)
 
-	err := dm.db.QueryRow(query, uid.String()).
-		Scan(&privateKey)
+	err := dm.db.QueryRow(query, uid.String()).Scan(&privateKey)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.GetPrivateKey(uid)
@@ -118,12 +112,9 @@ func (dm *DatabaseManager) GetPrivateKey(uid uuid.UUID) ([]byte, error) {
 func (dm *DatabaseManager) GetPublicKey(uid uuid.UUID) ([]byte, error) {
 	var publicKey []byte
 
-	query := fmt.Sprintf(
-		"SELECT public_key FROM %s WHERE uid = $1",
-		dm.tableName)
+	query := fmt.Sprintf("SELECT public_key FROM %s WHERE uid = $1", dm.tableName)
 
-	err := dm.db.QueryRow(query, uid.String()).
-		Scan(&publicKey)
+	err := dm.db.QueryRow(query, uid.String()).Scan(&publicKey)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.GetPublicKey(uid)
@@ -137,12 +128,9 @@ func (dm *DatabaseManager) GetPublicKey(uid uuid.UUID) ([]byte, error) {
 func (dm *DatabaseManager) GetAuthToken(uid uuid.UUID) (string, error) {
 	var authToken string
 
-	query := fmt.Sprintf(
-		"SELECT auth_token FROM %s WHERE uid = $1",
-		dm.tableName)
+	query := fmt.Sprintf("SELECT auth_token FROM %s WHERE uid = $1", dm.tableName)
 
-	err := dm.db.QueryRow(query, uid.String()).
-		Scan(&authToken)
+	err := dm.db.QueryRow(query, uid.String()).Scan(&authToken)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.GetAuthToken(uid)
@@ -167,13 +155,10 @@ func (dm *DatabaseManager) StartTransactionWithLock(ctx context.Context, uid uui
 
 	var id string
 
-	query := fmt.Sprintf(
-		"SELECT uid FROM %s WHERE uid = $1 FOR UPDATE",
-		dm.tableName)
+	query := fmt.Sprintf("SELECT uid FROM %s WHERE uid = $1 FOR UPDATE", dm.tableName)
 
 	// lock row FOR UPDATE
-	err = tx.QueryRow(query, uid).
-		Scan(&id)
+	err = tx.QueryRow(query, uid).Scan(&id)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.StartTransactionWithLock(ctx, uid)
@@ -205,12 +190,9 @@ func (dm *DatabaseManager) FetchIdentity(transactionCtx interface{}, uid uuid.UU
 
 	var id ent.Identity
 
-	query := fmt.Sprintf(
-		"SELECT * FROM %s WHERE uid = $1",
-		dm.tableName)
+	query := fmt.Sprintf("SELECT * FROM %s WHERE uid = $1", dm.tableName)
 
-	err := tx.QueryRow(query, uid.String()).
-		Scan(&id.Uid, &id.PrivateKey, &id.PublicKey, &id.Signature, &id.AuthToken)
+	err := tx.QueryRow(query, uid.String()).Scan(&id.Uid, &id.PrivateKey, &id.PublicKey, &id.Signature, &id.AuthToken)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.FetchIdentity(tx, uid)
@@ -227,13 +209,9 @@ func (dm *DatabaseManager) SetSignature(transactionCtx interface{}, uid uuid.UUI
 		return fmt.Errorf("transactionCtx for database manager is not of expected type *sql.Tx")
 	}
 
-	query := fmt.Sprintf(
-		"UPDATE %s SET signature = $1 WHERE uid = $2;",
-		dm.tableName)
+	query := fmt.Sprintf("UPDATE %s SET signature = $1 WHERE uid = $2;", dm.tableName)
 
-	_, err := tx.Exec(
-		query,
-		&signature, uid.String())
+	_, err := tx.Exec(query, &signature, uid.String())
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.SetSignature(tx, uid, signature)
@@ -253,12 +231,9 @@ func (dm *DatabaseManager) StoreNewIdentity(transactionCtx interface{}, identity
 	// make sure identity does not exist yet
 	var id string
 
-	query := fmt.Sprintf(
-		"SELECT uid FROM %s WHERE uid = $1 FOR UPDATE;",
-		dm.tableName)
+	query := fmt.Sprintf("SELECT uid FROM %s WHERE uid = $1 FOR UPDATE;", dm.tableName)
 
-	err := tx.QueryRow(query, identity.Uid).
-		Scan(&id)
+	err := tx.QueryRow(query, identity.Uid).Scan(&id)
 	if err != nil {
 		if dm.isConnectionAvailable(err) {
 			return dm.StoreNewIdentity(tx, identity)

--- a/main/adapters/repository/database_test.go
+++ b/main/adapters/repository/database_test.go
@@ -21,23 +21,8 @@ const (
 )
 
 func TestDatabaseManager_StoreNewIdentity(t *testing.T) {
-	var err error
-	testUid := uuid.MustParse(TestUUID).String()
-	priv, err := base64.StdEncoding.DecodeString(TestPrivKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pub, err := base64.StdEncoding.DecodeString(TestPubKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sig, err := base64.StdEncoding.DecodeString(TestSignature)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	conf := &config.Config{}
-	err = conf.Load("../../", "config.json")
+	err := conf.Load("../../", "config.json")
 	if err != nil {
 		t.Fatalf("ERROR: unable to load configuration: %s", err)
 	}
@@ -47,12 +32,9 @@ func TestDatabaseManager_StoreNewIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testIdentity := &ent.Identity{
-		Uid:        testUid,
-		PrivateKey: priv,
-		PublicKey:  pub,
-		Signature:  sig,
-		AuthToken:  TestAuthToken,
+	testIdentity, err := getTestIdentity()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -75,7 +57,7 @@ func TestDatabaseManager_StoreNewIdentity(t *testing.T) {
 
 	// clean up
 	deleteQuery := fmt.Sprintf("DELETE FROM %s WHERE uid = $1;", TestTableName)
-	_, err = dbManager.db.Exec(deleteQuery, testUid)
+	_, err = dbManager.db.Exec(deleteQuery, testIdentity.Uid)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,4 +67,30 @@ func TestDatabaseManager_StoreNewIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func getTestIdentity() (*ent.Identity, error) {
+	testUid, err := uuid.Parse(TestUUID)
+	if err != nil {
+		return nil, err
+	}
+	priv, err := base64.StdEncoding.DecodeString(TestPrivKey)
+	if err != nil {
+		return nil, err
+	}
+	pub, err := base64.StdEncoding.DecodeString(TestPubKey)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := base64.StdEncoding.DecodeString(TestSignature)
+	if err != nil {
+		return nil, err
+	}
+	return &ent.Identity{
+		Uid:        testUid.String(),
+		PrivateKey: priv,
+		PublicKey:  pub,
+		Signature:  sig,
+		AuthToken:  TestAuthToken,
+	}, nil
 }

--- a/main/adapters/repository/database_test.go
+++ b/main/adapters/repository/database_test.go
@@ -1,0 +1,88 @@
+package repository
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/ubirch/ubirch-client-go/main/config"
+	"github.com/ubirch/ubirch-client-go/main/ent"
+)
+
+const (
+	TestTableName = "test_identity"
+	TestUUID      = "2336c75d-a14a-47dd-80d9-3cbe9d560433"
+	TestPrivKey   = "Qkp+ZVAlEKCQNvI+OCbY7LKcQVW5iKfFMfzedTI3uG0="
+	TestPubKey    = "bvXP3mQ42hXpcqo0ms7Lr1n6Q4L5CsS8HXk0mdXlsXLwYjd35jLlX3iHrXMgUH92N8ujbZ3h3TnLk8a0GikUbg=="
+	TestSignature = "XqfjRkM0g9swes9osaoptFCFau4Qq3jX+bv+SwPLkUARs8MRm6uRj3VCbvF3JZUlHAEuXmAn849vV9e71KGjDQ=="
+	TestAuthToken = "TEST_auth"
+)
+
+func TestDatabaseManager_StoreNewIdentity(t *testing.T) {
+	var err error
+	testUid := uuid.MustParse(TestUUID).String()
+	priv, err := base64.StdEncoding.DecodeString(TestPrivKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := base64.StdEncoding.DecodeString(TestPubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(TestSignature)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conf := &config.Config{}
+	err = conf.Load("../../", "config.json")
+	if err != nil {
+		t.Fatalf("ERROR: unable to load configuration: %s", err)
+	}
+
+	dbManager, err := NewSqlDatabaseInfo(conf.PostgresDSN, TestTableName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testIdentity := &ent.Identity{
+		Uid:        testUid,
+		PrivateKey: priv,
+		PublicKey:  pub,
+		Signature:  sig,
+		AuthToken:  TestAuthToken,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tx, err := dbManager.StartTransaction(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dbManager.StoreNewIdentity(tx, testIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = dbManager.CloseTransaction(tx, Commit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// clean up
+	deleteQuery := fmt.Sprintf("DELETE FROM %s WHERE uid = $1;", TestTableName)
+	_, err = dbManager.db.Exec(deleteQuery, testUid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dropTableQuery := fmt.Sprintf("DROP TABLE %s;", TestTableName)
+	_, err = dbManager.db.Exec(dropTableQuery)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/main/adapters/repository/init_db.go
+++ b/main/adapters/repository/init_db.go
@@ -180,7 +180,7 @@ func checkVersion(ctx context.Context, dm *DatabaseManager) (*sql.Tx, bool, erro
 		return nil, false, err
 	}
 
-	if _, err := dm.db.Exec(CreateTable(PostgresVersion, vars.PostgreSqlIdentityTableName)); err != nil {
+	if _, err := dm.db.Exec(CreateTable(PostgresVersion, vars.PostgreSqlVersionTableName)); err != nil {
 		return tx, false, err
 	}
 

--- a/main/config/config.go
+++ b/main/config/config.go
@@ -51,26 +51,22 @@ var IsDevelopment bool
 
 // configuration of the client
 type Config struct {
-	Devices          map[string]string `json:"devices"`                               // maps UUIDs to backend auth tokens (mandatory)
-	Secret16Base64   string            `json:"secret" envconfig:"secret"`             // 16 bytes secret used to encrypt the key store (mandatory for migration) LEGACY
-	Secret32Base64   string            `json:"secret32" envconfig:"secret32"`         // 32 byte secret used to encrypt the key store (mandatory)
-	RegisterAuth     string            `json:"registerAuth"`                          // auth token needed for new identity registration
-	Env              string            `json:"env"`                                   // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
-	DsnInitContainer bool              `json:"DSN_InitDb" envconfig:"DSN_InitDb"`     // flag to determine if a database should be used for context management
-	DsnHost          string            `json:"DSN_Host" envconfig:"DSN_Host"`         // database host name
-	DsnUser          string            `json:"DSN_User" envconfig:"DSN_User"`         // database user name
-	DsnPassword      string            `json:"DSN_Password" envconfig:"DSN_Password"` // database password
-	DsnDb            string            `json:"DSN_Database" envconfig:"DSN_Database"` // database name
-	CSR_Country      string            `json:"CSR_country"`                           // subject country for public key Certificate Signing Requests
-	CSR_Organization string            `json:"CSR_organization"`                      // subject organization for public key Certificate Signing Requests
-	TCP_addr         string            `json:"TCP_addr"`                              // the TCP address for the server to listen on, in the form "host:port", defaults to ":8080"
-	TLS              bool              `json:"TLS"`                                   // enable serving HTTPS endpoints, defaults to 'false'
-	TLS_CertFile     string            `json:"TLSCertFile"`                           // filename of TLS certificate file name, defaults to "cert.pem"
-	TLS_KeyFile      string            `json:"TLSKeyFile"`                            // filename of TLS key file name, defaults to "key.pem"
-	CORS             bool              `json:"CORS"`                                  // enable CORS, defaults to 'false'
-	CORS_Origins     []string          `json:"CORS_origins"`                          // list of allowed origin hosts, defaults to ["*"]
-	Debug            bool              `json:"debug"`                                 // enable extended debug output, defaults to 'false'
-	LogTextFormat    bool              `json:"logTextFormat"`                         // log in text format for better human readability, default format is JSON
+	Devices          map[string]string `json:"devices"`                              // maps UUIDs to backend auth tokens (mandatory)
+	Secret16Base64   string            `json:"secret" envconfig:"secret"`            // 16 bytes secret used to encrypt the key store (mandatory for migration) LEGACY
+	Secret32Base64   string            `json:"secret32" envconfig:"secret32"`        // 32 byte secret used to encrypt the key store (mandatory)
+	RegisterAuth     string            `json:"registerAuth"`                         // auth token needed for new identity registration
+	Env              string            `json:"env"`                                  // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
+	PostgresDSN      string            `json:"postgresDSN" envconfig:"POSTGRES_DSN"` // data source name for postgres database
+	CSR_Country      string            `json:"CSR_country"`                          // subject country for public key Certificate Signing Requests
+	CSR_Organization string            `json:"CSR_organization"`                     // subject organization for public key Certificate Signing Requests
+	TCP_addr         string            `json:"TCP_addr"`                             // the TCP address for the server to listen on, in the form "host:port", defaults to ":8080"
+	TLS              bool              `json:"TLS"`                                  // enable serving HTTPS endpoints, defaults to 'false'
+	TLS_CertFile     string            `json:"TLSCertFile"`                          // filename of TLS certificate file name, defaults to "cert.pem"
+	TLS_KeyFile      string            `json:"TLSKeyFile"`                           // filename of TLS key file name, defaults to "key.pem"
+	CORS             bool              `json:"CORS"`                                 // enable CORS, defaults to 'false'
+	CORS_Origins     []string          `json:"CORS_origins"`                         // list of allowed origin hosts, defaults to ["*"]
+	Debug            bool              `json:"debug"`                                // enable extended debug output, defaults to 'false'
+	LogTextFormat    bool              `json:"logTextFormat"`                        // log in text format for better human readability, default format is JSON
 	SecretBytes32    []byte            // the decoded 32 byte key store secret for database (set automatically)
 	KeyService       string            // key service URL (set automatically)
 	IdentityService  string            // identity service URL (set automatically)

--- a/main/config/config_test.go
+++ b/main/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const expectedConfig = `{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","secret32":"VsCwmGssk7Ho2APyq1reGAKkB/+e8GlRfhM3NbYQWPU=","registerAuth":"test123","env":"","DSN_InitDb":false,"DSN_Host":"","DSN_User":"","DSN_Password":"","DSN_Database":"","CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"SecretBytes32":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":"","ConfigDir":""}`
+const expectedConfig = `{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","secret32":"VsCwmGssk7Ho2APyq1reGAKkB/+e8GlRfhM3NbYQWPU=","registerAuth":"test123","env":"","postgresDSN":"","CSR_country":"","CSR_organization":"","TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"debug":false,"logTextFormat":false,"SecretBytes32":null,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":"","ConfigDir":""}`
 
 func TestConfig(t *testing.T) {
 	configBytes := []byte(expectedConfig)

--- a/main/vars/vars.go
+++ b/main/vars/vars.go
@@ -2,7 +2,6 @@ package vars
 
 const (
 	PostgreSql                  string = "postgres"
-	PostgreSqlPort              int    = 5432
 	PostgreSqlIdentityTableName string = "identity"
 	PostgreSqlVersionTableName  string = "version"
 	MigrateArg                  string = "--migrate"


### PR DESCRIPTION
**Changed:**

- configuration for postgres database consists of only the DSN: `PostgresDSN`
  - deprecated `DSN_InitDb`, client will connect to DB if `PostgresDSN` is set
  - deprecated `DSN_Host`, `DSN_User`, `DSN_Password`, `DSN_Database`, replaced by `PostgresDSN`

**Added:**
- tests for database