### PR TITLE
run as unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ VOLUME /data
 EXPOSE 8080/tcp
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder app/main/main ubirch-client
+
+USER 65534
 ENTRYPOINT ["/ubirch-client"]
 CMD ["/data"]


### PR DESCRIPTION
The application used to run as root inside the container. This
commit introduces an unprivileged user, that is being used to run
the executable. This hardens the application against certain
attack vectors.