### PR TITLE
Drop support for multi-arch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,14 @@ ARG VERSION=devbuild
 ARG REVISION=0000000
 WORKDIR /app/main
 RUN \
-    CGO_ENABLED=0 \
     GOOS=linux \
     GOPROXY=https://proxy.golang.org,direct \
     go build -trimpath -ldflags "-buildid= -s -w -X main.Version=$VERSION -X main.Revision=$REVISION" -o main .
 
 
-FROM scratch
+FROM debian:bullseye
 VOLUME /data
 EXPOSE 8080/tcp
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder app/main/main ubirch-client
 ENTRYPOINT ["/ubirch-client"]
 CMD ["/data"]

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ IMAGE_ARCHS := amd64 arm arm64 386 # supported architectures
 GO = go
 GO_VERSION := 1.16
 LDFLAGS = -ldflags "-buildid= -s -w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)"
-GO_BUILD = $(GO) build -tags="netgo" -trimpath $(LDFLAGS)
+GO_BUILD = $(GO) build -trimpath $(LDFLAGS)
 UPX=upx --quiet --quiet
 DOCKER = DOCKER_CLI_EXPERIMENTAL=enabled DOCKER_BUILDKIT=1 docker
 GO_LINTER_IMAGE = golangci/golangci-lint:v1.32.1
@@ -80,74 +80,12 @@ image:
 
 # Publish publishes the built image.
 .PHONY: publish
-publish:
-# this would be the easy way:
-# (after depending on 'image' target)
-#	$(DOCKER) push $(IMAGE_REPO):$(IMAGE_TAG)
-# .. but we want multi-arch images:
-#	First we need to build the individual images
-	@for arch in $(IMAGE_ARCHS) ; do \
-		echo Building "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" ; \
-		$(DOCKER) build -t "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" \
-			--build-arg="GOARCH=$${arch}" \
-			--build-arg="VERSION=$(VERSION)" \
-			--build-arg="REVISION=$(REVISION)" \
-			--build-arg="GOVERSION=$(GO_VERSION)" \
-			--label="org.opencontainers.image.title=$(NAME)" \
-			--label="org.opencontainers.image.created=$(NOW)" \
-			--label="org.opencontainers.image.source=$(SRC_URL)" \
-			--label="org.opencontainers.image.version=$(VERSION)" \
-			--label="org.opencontainers.image.revision=$(REVISION)" . \
-		; \
-	done
-#	The manifest-tool is not able to work if the images are not already
-#	Pushed to a remote docker repository!
-#	We are also not able to set the architecture of the tags at this time,
-#	so they will be treated as AMD64 and clutter the tags list.
-	@for arch in $(IMAGE_ARCHS) ; do \
-		echo Pushing "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" ; \
-		$(DOCKER) push "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" ;\
-	done
-#	removing manifests is neccessary, otherwise the manifest-tool will
-#	get stuck with no way of creating new manifests with the same name as
-#	existing ones.
-	rm ~/.docker/manifests -rf
-#	First we create the new manifest, inserting all the tags into it.
-#	Note that their architecture will still be referred as "amd64" at
-#	this point.
-	$(DOCKER) manifest create $(IMAGE_REPO):$(IMAGE_TAG) \
-		$(IMAGE_REPO):$(IMAGE_TAG)-amd64 \
-		$(IMAGE_REPO):$(IMAGE_TAG)-arm \
-		$(IMAGE_REPO):$(IMAGE_TAG)-arm64 \
-		$(IMAGE_REPO):$(IMAGE_TAG)-386
-#	Now we can update the freshly created manifest, so the architecture
-#	of our custom image tags are correct.
-	$(DOCKER) manifest annotate --os=linux --arch=amd64 \
-		$(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)-amd64
-	$(DOCKER) manifest annotate --os=linux --arch=arm --variant=v7 \
-		$(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)-arm
-	$(DOCKER) manifest annotate --os=linux --arch=arm64 --variant=v8 \
-		$(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)-arm64
-	$(DOCKER) manifest annotate --os=linux --arch=386 \
-		$(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):$(IMAGE_TAG)-386
-#	Finally we push it, creating a new multi-arch tag on the dockerhub.
-	$(DOCKER) manifest push $(IMAGE_REPO):$(IMAGE_TAG)
-	
+publish: image
+	$(DOCKER) push $(IMAGE_REPO):$(IMAGE_TAG)	
 
 tag-stable:
-#   As we have no way of copying this manifest, we need to do it all
-#   over again.
-	$(DOCKER) manifest create $(IMAGE_REPO):stable \
-		$(IMAGE_REPO):$(IMAGE_TAG)-amd64 \
-		$(IMAGE_REPO):$(IMAGE_TAG)-arm32v7 \
-		$(IMAGE_REPO):$(IMAGE_TAG)-arm64v8
-	$(DOCKER) manifest annotate --os=linux --arch=amd64 \
-		$(IMAGE_REPO):latest $(IMAGE_REPO):$(IMAGE_TAG)-amd64
-	$(DOCKER) manifest annotate --os=linux --arch=arm --variant=v7 \
-		$(IMAGE_REPO):latest $(IMAGE_REPO):$(IMAGE_TAG)-arm32v7
-	$(DOCKER) manifest annotate --os=linux --arch=arm64  --variant=v8 \
-		$(IMAGE_REPO):latest $(IMAGE_REPO):$(IMAGE_TAG)-arm64v8
-	$(DOCKER) manifest push $(IMAGE_REPO):stable
+	$(DOCKER) tag $(IMAGE_REPO):$(IMAGE_TAG) $(IMAGE_REPO):stable
+	$(DOCKER) push $(IMAGE_REPO):stable
 
 .PHONY: publish-branch
 publish-branch: IMAGE_TAG=$(CURRENT_BRANCH)
@@ -158,7 +96,3 @@ clean:
 	$(MAKE) clean -C main
 	rm -rf build/
 	$(DOCKER) image rm $(IMAGE_REPO):$(IMAGE_TAG) | true
-	@for arch in $(IMAGE_ARCHS) ; do \
-		$(DOCKER) image rm "$(IMAGE_REPO):$(IMAGE_TAG)-$${arch}" | true ;\
-	done
-	echo "NOTE: some multi-arch images may not have been deleted by the target"

--- a/main/Makefile
+++ b/main/Makefile
@@ -38,27 +38,15 @@ SRC_URL = https://gitlab.com/ubirch/ubirch-client-go.git
 GO = go
 GO_VERSION := 1.16
 LDFLAGS = -ldflags "-buildid= -s -w -X main.Version=$(VERSION) -X main.Revision=$(REVISION)"
-GO_BUILD = $(GO) build -tags="netgo" -trimpath $(LDFLAGS)
+GO_BUILD = $(GO) build -trimpath $(LDFLAGS)
 UPX=upx --quiet --quiet
 
 .PHONY: build
 build: binaries
 
 binaries: build/bin/$(NAME).linux_amd64
-binaries: build/bin/$(NAME).linux_arm
-binaries: build/bin/$(NAME).linux_arm64
-binaries: build/bin/$(NAME).linux_386
-binaries: build/bin/$(NAME).windows_amd64.exe
 build/bin/$(NAME).linux_amd64:
-	CGO=0 GOOS=linux GOARCH=amd64 $(GO_BUILD) -o $@ .
-build/bin/$(NAME).linux_arm:
-	CGO=0 GOOS=linux GOARCH=arm GOARM=7 $(GO_BUILD) -o $@ .
-build/bin/$(NAME).linux_arm64:
-	CGO=0 GOOS=linux GOARCH=arm64 $(GO_BUILD) -o $@ .
-build/bin/$(NAME).linux_386:
-	CGO=0 GOOS=linux GOARCH=386 $(GO_BUILD) -o $@ .
-build/bin/$(NAME).windows_amd64.exe:
-	CGO=0 GOOS=windows GOARCH=amd64 $(GO_BUILD) -o $@ .
+	GOOS=linux GOARCH=amd64 $(GO_BUILD) -o $@ .
 
 pack: binaries
 	$(UPX) build/bin/*


### PR DESCRIPTION
As we are depending on CGO, make sure that we only build image for the current architecture.
This will shave a minute or two from the build process