### PR TITLE
CPI-47 deactivation endpoint

### DIFF
--- a/main/adapters/clients/ubirch_identity_client.go
+++ b/main/adapters/clients/ubirch_identity_client.go
@@ -83,11 +83,10 @@ func (c *IdentityServiceClient) IsKeyRegistered(id uuid.UUID, pubKey []byte) (bo
 	return false, nil
 }
 
-func (c *IdentityServiceClient) SubmitKeyRegistration(uid uuid.UUID, auth string, cert []byte) error {
+func (c *IdentityServiceClient) SubmitKeyRegistration(uid uuid.UUID, cert []byte) error {
 	log.Debugf("%s: registering public key at key service", uid)
 
-	keyRegHeader := ubirchHeader(uid, auth)
-	keyRegHeader["content-type"] = "application/json"
+	keyRegHeader := map[string]string{"content-type": "application/json"}
 
 	resp, err := Post(c.KeyServiceURL, cert, keyRegHeader)
 	if err != nil {
@@ -97,6 +96,22 @@ func (c *IdentityServiceClient) SubmitKeyRegistration(uid uuid.UUID, auth string
 		return fmt.Errorf("key registration failed: (%d) %q", resp.StatusCode, resp.Content)
 	}
 	log.Debugf("%s: key registration successful: (%d) %s", uid, resp.StatusCode, string(resp.Content))
+	return nil
+}
+
+func (c *IdentityServiceClient) RequestKeyDeletion(uid uuid.UUID, cert []byte) error {
+	log.Debugf("%s: deleting public key at key service", uid)
+
+	keyDelHeader := map[string]string{"content-type": "application/json"}
+
+	resp, err := Delete(c.KeyServiceURL, cert, keyDelHeader)
+	if err != nil {
+		return fmt.Errorf("error sending key deletion request: %v", err)
+	}
+	if h.HttpFailed(resp.StatusCode) {
+		return fmt.Errorf("key deletion failed: (%d) %q", resp.StatusCode, resp.Content)
+	}
+	log.Debugf("%s: key deletion successful: (%d) %s", uid, resp.StatusCode, string(resp.Content))
 	return nil
 }
 

--- a/main/adapters/clients/ubirch_service_client.go
+++ b/main/adapters/clients/ubirch_service_client.go
@@ -18,9 +18,17 @@ type UbirchServiceClient struct {
 // Post submits a message to a backend service
 // returns the response or encountered errors
 func Post(serviceURL string, data []byte, header map[string]string) (h.HTTPResponse, error) {
+	return sendRequest(http.MethodPost, serviceURL, data, header)
+}
+
+func Delete(serviceURL string, data []byte, header map[string]string) (h.HTTPResponse, error) {
+	return sendRequest(http.MethodDelete, serviceURL, data, header)
+}
+
+func sendRequest(method string, serviceURL string, data []byte, header map[string]string) (h.HTTPResponse, error) {
 	client := &http.Client{Timeout: h.BackendRequestTimeout}
 
-	req, err := http.NewRequest(http.MethodPost, serviceURL, bytes.NewBuffer(data))
+	req, err := http.NewRequest(method, serviceURL, bytes.NewBuffer(data))
 	if err != nil {
 		return h.HTTPResponse{}, fmt.Errorf("can't make new post request: %v", err)
 	}

--- a/main/adapters/handlers/identity_handler.go
+++ b/main/adapters/handlers/identity_handler.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
-	"github.com/ubirch/ubirch-client-go/main/auditlogger"
 
 	"github.com/google/uuid"
 	"github.com/ubirch/ubirch-client-go/main/adapters/repository"
+	"github.com/ubirch/ubirch-client-go/main/auditlogger"
 	"github.com/ubirch/ubirch-client-go/main/ent"
 
 	log "github.com/sirupsen/logrus"

--- a/main/adapters/handlers/identity_handler.go
+++ b/main/adapters/handlers/identity_handler.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
+	"github.com/ubirch/ubirch-client-go/main/auditlogger"
 
 	"github.com/google/uuid"
 	"github.com/ubirch/ubirch-client-go/main/adapters/repository"
@@ -227,6 +228,9 @@ func (i *IdentityHandler) DeactivateKey(uid uuid.UUID) error {
 		return fmt.Errorf("%s: commiting transaction to store active flag failed after successful key deletion at ubirch identity service: %v", uid, err)
 	}
 
+	infos := fmt.Sprintf("\"hwDeviceId\":\"%s\"", uid)
+	auditlogger.AuditLog("deactivate", "device", infos)
+
 	return nil
 }
 
@@ -275,6 +279,9 @@ func (i *IdentityHandler) ReactivateKey(uid uuid.UUID) error {
 	if err != nil {
 		return fmt.Errorf("%s: commiting transaction to store active flag failed after successful key registration at ubirch identity service: %v", uid, err)
 	}
+
+	infos := fmt.Sprintf("\"hwDeviceId\":\"%s\"", uid)
+	auditlogger.AuditLog("activate", "device", infos)
 
 	return nil
 }

--- a/main/adapters/handlers/identity_handler_test.go
+++ b/main/adapters/handlers/identity_handler_test.go
@@ -74,15 +74,7 @@ func TestIdentityHandler_InitIdentity(t *testing.T) {
 	assert.True(t, found)
 	assert.True(t, ok)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	tx, err := p.StartTransaction(ctx)
-	require.NoError(t, err)
-
-	signature, err := p.LoadSignature(tx, testUuid)
-	require.NoError(t, err)
-	assert.Equal(t, make([]byte, p.SignatureLength()), signature)
+	assert.Equal(t, make([]byte, p.SignatureLength()), initializedIdentity.Signature)
 
 	hash := make([]byte, p.HashLength())
 	rand.Read(hash)

--- a/main/adapters/handlers/identity_handler_test.go
+++ b/main/adapters/handlers/identity_handler_test.go
@@ -318,11 +318,11 @@ func TestIdentityHandler_InitIdentities(t *testing.T) {
 	require.Error(t, err)
 }
 
-func MockSubmitKeyRegistration(uuid.UUID, string, []byte) error {
+func MockSubmitKeyRegistration(uuid.UUID, []byte) error {
 	return nil
 }
 
-func MockSubmitKeyRegistrationBad(uuid.UUID, string, []byte) error {
+func MockSubmitKeyRegistrationBad(uuid.UUID, []byte) error {
 	return fmt.Errorf("fail")
 }
 

--- a/main/adapters/handlers/signer.go
+++ b/main/adapters/handlers/signer.go
@@ -71,12 +71,6 @@ func (s *Signer) Chain(msg h.HTTPRequest, ctx context.Context) h.HTTPResponse {
 		return errorResponse(http.StatusBadRequest, "key deactivated")
 	}
 
-	_, err = s.Protocol.LoadPrivateKey(msg.ID)
-	if err != nil {
-		log.Errorf("%s: could not load private key: %v", msg.ID, err)
-		return errorResponse(http.StatusInternalServerError, "")
-	}
-
 	tx, err := s.Protocol.StartTransaction(ctx)
 	if err != nil {
 		log.Errorf("%s: initializing transaction failed: %v", msg.ID, err)
@@ -131,12 +125,6 @@ func (s *Signer) Sign(msg h.HTTPRequest, op h.Operation) h.HTTPResponse {
 	if !active {
 		log.Warnf("%s: key deactivated", msg.ID)
 		return errorResponse(http.StatusBadRequest, "key deactivated")
-	}
-
-	_, err = s.Protocol.LoadPrivateKey(msg.ID)
-	if err != nil {
-		log.Errorf("%s: could not load private key: %v", msg.ID, err)
-		return errorResponse(http.StatusInternalServerError, "")
 	}
 
 	uppBytes, err := s.getSignedUPP(msg.ID, msg.Hash, op)

--- a/main/adapters/handlers/signer.go
+++ b/main/adapters/handlers/signer.go
@@ -60,9 +60,20 @@ type Signer struct {
 func (s *Signer) Chain(msg h.HTTPRequest, ctx context.Context) h.HTTPResponse {
 	log.Infof("%s: anchor hash [chained]: %s", msg.ID, base64.StdEncoding.EncodeToString(msg.Hash[:]))
 
-	_, err := s.Protocol.LoadPrivateKey(msg.ID)
+	active, err := s.Protocol.LoadActiveFlag(msg.ID)
 	if err != nil {
-		log.Errorf("%s: could not fetch private Key for UUID: %v", msg.ID, err)
+		log.Errorf("%s: could not load active flag: %v", msg.ID, err)
+		return errorResponse(http.StatusInternalServerError, "")
+	}
+
+	if !active {
+		log.Warnf("%s: key deactivated", msg.ID)
+		return errorResponse(http.StatusBadRequest, "key deactivated")
+	}
+
+	_, err = s.Protocol.LoadPrivateKey(msg.ID)
+	if err != nil {
+		log.Errorf("%s: could not load private key: %v", msg.ID, err)
 		return errorResponse(http.StatusInternalServerError, "")
 	}
 
@@ -111,9 +122,20 @@ func (s *Signer) Chain(msg h.HTTPRequest, ctx context.Context) h.HTTPResponse {
 func (s *Signer) Sign(msg h.HTTPRequest, op h.Operation) h.HTTPResponse {
 	log.Infof("%s: %s hash: %s", msg.ID, op, base64.StdEncoding.EncodeToString(msg.Hash[:]))
 
-	_, err := s.Protocol.LoadPrivateKey(msg.ID)
+	active, err := s.Protocol.LoadActiveFlag(msg.ID)
 	if err != nil {
-		log.Errorf("%s: could not load private key for UUID: %v", msg.ID, err)
+		log.Errorf("%s: could not load active flag: %v", msg.ID, err)
+		return errorResponse(http.StatusInternalServerError, "")
+	}
+
+	if !active {
+		log.Warnf("%s: key deactivated", msg.ID)
+		return errorResponse(http.StatusBadRequest, "key deactivated")
+	}
+
+	_, err = s.Protocol.LoadPrivateKey(msg.ID)
+	if err != nil {
+		log.Errorf("%s: could not load private key: %v", msg.ID, err)
 		return errorResponse(http.StatusInternalServerError, "")
 	}
 

--- a/main/adapters/handlers/signer.go
+++ b/main/adapters/handlers/signer.go
@@ -72,9 +72,9 @@ func (s *Signer) Chain(msg h.HTTPRequest, ctx context.Context) h.HTTPResponse {
 		return errorResponse(http.StatusServiceUnavailable, "")
 	}
 
-	prevSignature, err := s.Protocol.LoadSignature(tx, msg.ID)
+	prevSignature, err := s.Protocol.LoadSignatureForUpdate(tx, msg.ID)
 	if err != nil {
-		log.Errorf("%s: could not fetch identity from storage: %v", msg.ID, err)
+		log.Errorf("%s: could not load signature: %v", msg.ID, err)
 		return errorResponse(http.StatusInternalServerError, "")
 	}
 

--- a/main/adapters/http_server/active_updater.go
+++ b/main/adapters/http_server/active_updater.go
@@ -59,7 +59,7 @@ func UpdateActive(auth string,
 		SendResponse(w, HTTPResponse{
 			StatusCode: http.StatusOK,
 			Header:     http.Header{"Content-Type": {"text/plain; charset=utf-8"}},
-			Content:    []byte(action + "successful"),
+			Content:    []byte(action + " successful"),
 		})
 	}
 }

--- a/main/adapters/http_server/active_updater.go
+++ b/main/adapters/http_server/active_updater.go
@@ -1,0 +1,62 @@
+package http_server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type ActiveUpdatePayload struct {
+	Uid    uuid.UUID `json:"id"`
+	Active bool      `json:"active"`
+}
+
+func UpdateActive(auth string,
+	deactivate func(uid uuid.UUID) HTTPResponse,
+	reactivate func(uid uuid.UUID) HTTPResponse) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if AuthToken(r.Header) != auth {
+			log.Warnf("unauthorized key deactivation/reactivation attempt")
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+			return
+		}
+
+		activeUpdatePayload, err := GetActiveUpdatePayload(r)
+		if err != nil {
+			log.Warnf("unsuccessful key deactivation/reactivation attempt: %v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		resp := HTTPResponse{}
+
+		if activeUpdatePayload.Active {
+			resp = reactivate(activeUpdatePayload.Uid)
+		} else {
+			resp = deactivate(activeUpdatePayload.Uid)
+		}
+
+		SendResponse(w, resp)
+	}
+}
+
+func GetActiveUpdatePayload(r *http.Request) (*ActiveUpdatePayload, error) {
+	contentType := ContentType(r.Header)
+	if contentType != JSONType {
+		return nil, fmt.Errorf("invalid content-type: expected %s, got %s", JSONType, contentType)
+	}
+
+	payload := &ActiveUpdatePayload{}
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&payload); err != nil {
+		return nil, err
+	}
+	if payload.Uid == uuid.Nil {
+		return nil, fmt.Errorf("empty uuid")
+	}
+	return payload, nil
+}

--- a/main/adapters/http_server/common.go
+++ b/main/adapters/http_server/common.go
@@ -31,6 +31,7 @@ const (
 	HashEndpoint           = "/hash"
 	RegisterEndpoint       = "/register"
 	CSREndpoint            = "/csr"
+	ActiveUpdateEndpoint   = "/device/updateActive"
 	MetricsEndpoint        = "/metrics"
 	LivenessCheckEndpoint  = "/healthz"
 	ReadinessCheckEndpoint = "/readyz"

--- a/main/adapters/http_server/common.go
+++ b/main/adapters/http_server/common.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -50,6 +51,11 @@ const (
 var (
 	UUIDPath      = fmt.Sprintf("/{%s}", UUIDKey)
 	OperationPath = fmt.Sprintf("/{%s}", OperationKey)
+
+	ErrUnknown            = errors.New("identity unknown")
+	ErrAlreadyInitialized = errors.New("identity already registered")
+	ErrAlreadyDeactivated = errors.New("key already deactivated")
+	ErrAlreadyActivated   = errors.New("key already activated")
 )
 
 type HTTPRequest struct {

--- a/main/adapters/http_server/csr_fetcher.go
+++ b/main/adapters/http_server/csr_fetcher.go
@@ -1,16 +1,11 @@
 package http_server
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/google/uuid"
 
 	log "github.com/sirupsen/logrus"
-)
-
-var (
-	ErrUnknown = errors.New("unknown identity")
 )
 
 type GetCSR func(uid uuid.UUID) (csr []byte, err error)
@@ -36,7 +31,7 @@ func FetchCSR(auth string, get GetCSR) http.HandlerFunc {
 			case ErrUnknown:
 				Error(uid, w, err, http.StatusNotFound)
 			default:
-				log.Errorf("%s: %v", uid, err)
+				log.Errorf("%s: FetchCSR: %v", uid, err)
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			}
 			return

--- a/main/adapters/http_server/identity_registerer.go
+++ b/main/adapters/http_server/identity_registerer.go
@@ -2,7 +2,6 @@ package http_server
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -11,10 +10,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	prom "github.com/ubirch/ubirch-client-go/main/prometheus"
-)
-
-var (
-	ErrAlreadyInitialized = errors.New("identity already registered")
 )
 
 type RegistrationPayload struct {
@@ -55,10 +50,8 @@ func Register(registerAuth string, initialize InitializeIdentity) http.HandlerFu
 
 		SendResponse(w, HTTPResponse{
 			StatusCode: http.StatusOK,
-			Header: http.Header{
-				"Content-Type": {BinType},
-			},
-			Content: csr,
+			Header:     http.Header{"Content-Type": {BinType}},
+			Content:    csr,
 		})
 
 		prom.IdentityCreationCounter.Inc()

--- a/main/adapters/http_server/resp.go
+++ b/main/adapters/http_server/resp.go
@@ -20,7 +20,7 @@ func SendResponse(w http.ResponseWriter, resp HTTPResponse) {
 		w.Header().Set(k, v[0])
 	}
 	w.WriteHeader(resp.StatusCode)
-	_, err := w.Write(resp.Content)
+	_, err := w.Write(append(resp.Content, '\n'))
 	if err != nil {
 		log.Errorf("unable to write response: %s", err)
 	}
@@ -37,7 +37,7 @@ func Health(server string) http.HandlerFunc {
 		w.Header().Set("Server", server)
 		w.Header().Set("Content-Type", TextType)
 		w.WriteHeader(http.StatusOK)
-		_, err := w.Write([]byte(http.StatusText(http.StatusOK)))
+		_, err := w.Write(append([]byte(http.StatusText(http.StatusOK)), '\n'))
 		if err != nil {
 			log.Errorf("unable to write response: %s", err)
 		}
@@ -60,7 +60,7 @@ func Ready(server string, readinessChecks []func() error) http.HandlerFunc {
 		w.Header().Set("Server", server)
 		w.Header().Set("Content-Type", TextType)
 		w.WriteHeader(status)
-		_, err := w.Write([]byte(http.StatusText(status)))
+		_, err := w.Write(append([]byte(http.StatusText(status)), '\n'))
 		if err != nil {
 			log.Errorf("unable to write response: %s", err)
 		}

--- a/main/adapters/repository/context_manager.go
+++ b/main/adapters/repository/context_manager.go
@@ -21,10 +21,11 @@ type ContextManager interface {
 	LoadIdentity(uuid.UUID) (*ent.Identity, error)
 
 	StoreActiveFlag(TransactionCtx, uuid.UUID, bool) error
-	LoadActiveFlag(TransactionCtx, uuid.UUID) (bool, error)
+	LoadActiveFlagForUpdate(TransactionCtx, uuid.UUID) (bool, error)
+	LoadActiveFlag(uuid.UUID) (bool, error)
 
 	StoreSignature(TransactionCtx, uuid.UUID, []byte) error
-	LoadSignature(TransactionCtx, uuid.UUID) ([]byte, error)
+	LoadSignatureForUpdate(TransactionCtx, uuid.UUID) ([]byte, error)
 
 	IsReady() error
 	Close() error

--- a/main/adapters/repository/context_manager.go
+++ b/main/adapters/repository/context_manager.go
@@ -20,6 +20,9 @@ type ContextManager interface {
 	StoreIdentity(TransactionCtx, ent.Identity) error
 	LoadIdentity(uuid.UUID) (*ent.Identity, error)
 
+	StoreActiveFlag(TransactionCtx, uuid.UUID, bool) error
+	LoadActiveFlag(TransactionCtx, uuid.UUID) (bool, error)
+
 	StoreSignature(TransactionCtx, uuid.UUID, []byte) error
 	LoadSignature(TransactionCtx, uuid.UUID) ([]byte, error)
 

--- a/main/adapters/repository/database.go
+++ b/main/adapters/repository/database.go
@@ -117,12 +117,14 @@ func (dm *DatabaseManager) StoreIdentity(transactionCtx TransactionCtx, i ent.Id
 }
 
 func (dm *DatabaseManager) LoadIdentity(uid uuid.UUID) (*ent.Identity, error) {
-	i := ent.Identity{}
+	i := ent.Identity{Uid: uid}
 
-	query := fmt.Sprintf("SELECT * FROM %s WHERE uid = $1", PostgresIdentityTableName)
+	query := fmt.Sprintf(
+		"SELECT private_key, public_key, signature, auth_token FROM %s WHERE uid = $1",
+		PostgresIdentityTableName)
 
 	err := dm.retry(func() error {
-		err := dm.db.QueryRow(query, uid.String()).Scan(&i.Uid, &i.PrivateKey, &i.PublicKey, &i.Signature, &i.AuthToken)
+		err := dm.db.QueryRow(query, uid).Scan(&i.PrivateKey, &i.PublicKey, &i.Signature, &i.AuthToken)
 		if err == sql.ErrNoRows {
 			return ErrNotExist
 		}

--- a/main/adapters/repository/database_init.go
+++ b/main/adapters/repository/database_init.go
@@ -30,8 +30,8 @@ var create = map[int]string{
 		"private_key BYTEA NOT NULL, "+
 		"public_key BYTEA NOT NULL, "+
 		"signature BYTEA NOT NULL, "+
-		"auth_token VARCHAR(255) NOT NULL), "+
-		"active boolean NOT NULL DEFAULT(TRUE);", PostgresIdentityTableName),
+		"auth_token VARCHAR(255) NOT NULL, "+
+		"active boolean NOT NULL DEFAULT(TRUE));", PostgresIdentityTableName),
 	PostgresVersion: fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s("+
 		"id VARCHAR(255) NOT NULL PRIMARY KEY, "+
 		"migration_version VARCHAR(255) NOT NULL);", PostgresVersionTableName),

--- a/main/adapters/repository/database_init.go
+++ b/main/adapters/repository/database_init.go
@@ -9,12 +9,13 @@ import (
 const (
 	PostgresIdentity = iota
 	PostgresVersion
-	PostgresIdentityTableName = "identity"
-	PostgresVersionTableName  = "version"
-	MigrationID               = "dbMigration"
-	MigrationVersionNoDB      = "0.0"
-	MigrationVersionInit      = "1.0.1"
-	MigrationVersionLatest    = "2.0"
+	PostgresIdentityTableName  = "identity"
+	PostgresVersionTableName   = "version"
+	MigrationID                = "dbMigration"
+	MigrationVersionNoDB       = "0.0"
+	MigrationVersionInit       = "1.0.1"
+	MigrationVersionHashedAuth = "2.0"
+	MigrationVersionLatest     = "3.0"
 )
 
 type Migration struct {
@@ -29,7 +30,8 @@ var create = map[int]string{
 		"private_key BYTEA NOT NULL, "+
 		"public_key BYTEA NOT NULL, "+
 		"signature BYTEA NOT NULL, "+
-		"auth_token VARCHAR(255) NOT NULL);", PostgresIdentityTableName),
+		"auth_token VARCHAR(255) NOT NULL), "+
+		"active boolean NOT NULL DEFAULT(TRUE);", PostgresIdentityTableName),
 	PostgresVersion: fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s("+
 		"id VARCHAR(255) NOT NULL PRIMARY KEY, "+
 		"migration_version VARCHAR(255) NOT NULL);", PostgresVersionTableName),

--- a/main/adapters/repository/database_test.go
+++ b/main/adapters/repository/database_test.go
@@ -46,6 +46,9 @@ func TestDatabaseManager(t *testing.T) {
 	_, err = dm.LoadSignature(tx, testIdentity.Uid)
 	assert.Equal(t, ErrNotExist, err)
 
+	_, err = dm.LoadActiveFlag(tx, testIdentity.Uid)
+	assert.Equal(t, ErrNotExist, err)
+
 	err = tx.Commit()
 	require.NoError(t, err)
 
@@ -67,6 +70,10 @@ func TestDatabaseManager(t *testing.T) {
 	sig, err := dm.LoadSignature(tx, testIdentity.Uid)
 	assert.NoError(t, err)
 	assert.Equal(t, testIdentity.Signature, sig)
+
+	active, err := dm.LoadActiveFlag(tx, testIdentity.Uid)
+	assert.NoError(t, err)
+	assert.True(t, active)
 
 	i, err := dm.LoadIdentity(testIdentity.Uid)
 	require.NoError(t, err)

--- a/main/adapters/repository/database_test.go
+++ b/main/adapters/repository/database_test.go
@@ -69,7 +69,7 @@ func TestDatabaseManager(t *testing.T) {
 	assert.Equal(t, testIdentity.Signature, sig)
 
 	i, err := dm.LoadIdentity(testIdentity.Uid)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, testIdentity.PrivateKey, i.PrivateKey)
 	assert.Equal(t, testIdentity.PublicKey, i.PublicKey)
 	assert.Equal(t, testIdentity.AuthToken, i.AuthToken)

--- a/main/adapters/repository/mocks.go
+++ b/main/adapters/repository/mocks.go
@@ -39,6 +39,14 @@ func (m *MockCtxMngr) LoadIdentity(u uuid.UUID) (*ent.Identity, error) {
 	return &id, nil
 }
 
+func (m *MockCtxMngr) StoreActiveFlag(t TransactionCtx, u uuid.UUID, a bool) error {
+	return nil
+}
+
+func (m *MockCtxMngr) LoadActiveFlag(t TransactionCtx, u uuid.UUID) (bool, error) {
+	return true, nil
+}
+
 func (m *MockCtxMngr) StoreSignature(t TransactionCtx, u uuid.UUID, s []byte) error {
 	tx, ok := t.(*mockTx)
 	if !ok {

--- a/main/adapters/repository/mocks.go
+++ b/main/adapters/repository/mocks.go
@@ -10,7 +10,8 @@ import (
 )
 
 type MockCtxMngr struct {
-	id ent.Identity
+	id     ent.Identity
+	active bool
 }
 
 var _ ContextManager = (*MockCtxMngr)(nil)
@@ -40,11 +41,16 @@ func (m *MockCtxMngr) LoadIdentity(u uuid.UUID) (*ent.Identity, error) {
 }
 
 func (m *MockCtxMngr) StoreActiveFlag(t TransactionCtx, u uuid.UUID, a bool) error {
+	m.active = a
 	return nil
 }
 
-func (m *MockCtxMngr) LoadActiveFlag(t TransactionCtx, u uuid.UUID) (bool, error) {
-	return true, nil
+func (m *MockCtxMngr) LoadActiveFlagForUpdate(t TransactionCtx, u uuid.UUID) (bool, error) {
+	return m.active, nil
+}
+
+func (m *MockCtxMngr) LoadActiveFlag(u uuid.UUID) (bool, error) {
+	return m.active, nil
 }
 
 func (m *MockCtxMngr) StoreSignature(t TransactionCtx, u uuid.UUID, s []byte) error {
@@ -61,7 +67,7 @@ func (m *MockCtxMngr) StoreSignature(t TransactionCtx, u uuid.UUID, s []byte) er
 	return nil
 }
 
-func (m *MockCtxMngr) LoadSignature(t TransactionCtx, u uuid.UUID) ([]byte, error) {
+func (m *MockCtxMngr) LoadSignatureForUpdate(t TransactionCtx, u uuid.UUID) ([]byte, error) {
 	tx, ok := t.(*mockTx)
 	if !ok {
 		return nil, fmt.Errorf("transactionCtx for MockCtxMngr is not of expected type *mockTx")
@@ -93,11 +99,12 @@ var _ TransactionCtx = (*mockTx)(nil)
 
 func (m *mockTx) Commit() error {
 	*m.id = m.idBuf
+	*m = mockTx{}
 	return nil
 }
 
-func (m mockTx) Rollback() error {
-	m.idBuf = ent.Identity{}
+func (m *mockTx) Rollback() error {
+	*m = mockTx{}
 	return nil
 }
 

--- a/main/adapters/repository/protocol_test.go
+++ b/main/adapters/repository/protocol_test.go
@@ -44,7 +44,7 @@ func TestProtocol(t *testing.T) {
 	tx, err := p.StartTransaction(ctx)
 	require.NoError(t, err)
 
-	_, err = p.LoadSignature(tx, testIdentity.Uid)
+	_, err = p.LoadSignatureForUpdate(tx, testIdentity.Uid)
 	assert.Equal(t, ErrNotExist, err)
 
 	err = tx.Commit()
@@ -77,7 +77,7 @@ func TestProtocol(t *testing.T) {
 	tx, err = p.StartTransaction(ctx)
 	require.NoError(t, err)
 
-	sig, err := p.LoadSignature(tx, testIdentity.Uid)
+	sig, err := p.LoadSignatureForUpdate(tx, testIdentity.Uid)
 	assert.NoError(t, err)
 	assert.Equal(t, testIdentity.Signature, sig)
 
@@ -218,7 +218,7 @@ func TestExtendedProtocol_StoreSignature(t *testing.T) {
 	tx, err = p.StartTransaction(ctx)
 	require.NoError(t, err)
 
-	_, err = p.LoadSignature(tx, testIdentity.Uid)
+	_, err = p.LoadSignatureForUpdate(tx, testIdentity.Uid)
 	require.NoError(t, err)
 
 	err = p.StoreSignature(tx, testIdentity.Uid, newSignature)
@@ -228,7 +228,7 @@ func TestExtendedProtocol_StoreSignature(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, tx2)
 
-	sig, err := p.LoadSignature(tx2, testIdentity.Uid)
+	sig, err := p.LoadSignatureForUpdate(tx2, testIdentity.Uid)
 	assert.NoError(t, err)
 	assert.Equal(t, newSignature, sig)
 }

--- a/main/auditlogger/audit_logger.go
+++ b/main/auditlogger/audit_logger.go
@@ -1,0 +1,36 @@
+package auditlogger
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	timeFormat    = time.RFC3339
+	version       = "1"
+	messageFormat = "%s: %s %s Infos(%s)" // "$Service: $action $object Infos(\"hwDeviceId\":\"$hwDeviceId\", \"hash\":\"$hash\")"
+	loggerName    = "com.ubirch.events.AuditLogger"
+	auditTag      = "AUDIT"
+)
+
+var (
+	service = "unknown"
+)
+
+func SetServiceName(serviceName string) {
+	service = serviceName
+}
+
+func getAuditLogFields() log.Fields {
+	return log.Fields{
+		"@timestamp":  time.Now().UTC().Format(timeFormat),
+		"@version":    version,
+		"logger_name": loggerName,
+		"tags":        []string{auditTag},
+	}
+}
+
+func AuditLog(action, object, infos string) {
+	log.WithFields(getAuditLogFields()).Infof(messageFormat, service, action, object, infos)
+}

--- a/main/go.mod
+++ b/main/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
-	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20211108150745-eaa9ee64b1ee
+	github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20211111205110-07b7b6e55429
 	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a

--- a/main/go.sum
+++ b/main/go.sum
@@ -110,8 +110,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IKw=
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20211108150745-eaa9ee64b1ee h1:pNlEOFmT1g1oHZp8e1cLy5TDNb4waaS95uwBXhF9JoM=
-github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20211108150745-eaa9ee64b1ee/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20211111205110-07b7b6e55429 h1:3St8spSZERHigsqQTjMg6TJ7R93DuU7mJ3MX84RnnMA=
+github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20211111205110-07b7b6e55429/go.mod h1:edMk+CtbW3ODrqcU0iYVBG8idrYWPrPCom+jXDhRDq0=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=

--- a/main/main.go
+++ b/main/main.go
@@ -111,6 +111,7 @@ func main() {
 	idHandler := &handlers.IdentityHandler{
 		Protocol:              protocol,
 		SubmitKeyRegistration: client.SubmitKeyRegistration,
+		RequestKeyDeletion:    client.RequestKeyDeletion,
 		SubmitCSR:             client.SubmitCSR,
 		SubjectCountry:        conf.CSR_Country,
 		SubjectOrganization:   conf.CSR_Organization,
@@ -155,6 +156,9 @@ func main() {
 
 	// set up endpoint for identity registration
 	httpServer.Router.Put(h.RegisterEndpoint, h.Register(conf.RegisterAuth, idHandler.InitIdentity))
+
+	// set up endpoint for key status updates (de-/re-activation)
+	httpServer.Router.Post(h.ActiveUpdateEndpoint, h.UpdateActive(conf.RegisterAuth, idHandler.DeactivateKey, idHandler.ReactivateKey))
 
 	// set up endpoint for CSRs
 	fetchCSREndpoint := path.Join(h.UUIDPath, h.CSREndpoint) // /<uuid>/csr

--- a/main/main.go
+++ b/main/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ubirch/ubirch-client-go/main/adapters/clients"
 	"github.com/ubirch/ubirch-client-go/main/adapters/handlers"
 	"github.com/ubirch/ubirch-client-go/main/adapters/repository"
+	"github.com/ubirch/ubirch-client-go/main/auditlogger"
 	"github.com/ubirch/ubirch-client-go/main/config"
 
 	log "github.com/sirupsen/logrus"
@@ -68,6 +69,7 @@ func main() {
 
 	log.SetFormatter(&log.JSONFormatter{})
 	log.Printf("UBIRCH client (version=%s, revision=%s)", Version, Revision)
+	auditlogger.SetServiceName(serviceName)
 
 	// read configuration
 	conf := &config.Config{}


### PR DESCRIPTION
**Added:**

- endpoint for key de- and re-activation
    ```
    POST /device/updateActive
    Header: X-Auth-Token: registerAuth
    Body: {id: ${device_uuid}, active: Boolean}
    ```
  - deactivation deletes public key at identity service
  - reactivation registers public key at identity service
- additional column in db table `active` [bool]
- migration script, start with `--migrate` flag to upgrade db version