### PR TITLE
CPI-960 clear cached keys after failed key registration attempt

### DIFF
--- a/main/adapters/handlers/identity_handler.go
+++ b/main/adapters/handlers/identity_handler.go
@@ -111,6 +111,7 @@ func (i *IdentityHandler) InitIdentity(uid uuid.UUID, auth string) (csrPEM []byt
 	// register public key at the ubirch backend
 	err = i.registerPublicKey(uid)
 	if err != nil {
+		i.Protocol.ClearKeysFromCache(uid)
 		return nil, err
 	}
 

--- a/main/adapters/handlers/identity_handler_test.go
+++ b/main/adapters/handlers/identity_handler_test.go
@@ -126,8 +126,9 @@ func TestIdentityHandler_InitIdentity_BadRegistration(t *testing.T) {
 	_, err = idHandler.InitIdentity(testUuid, testAuth)
 	assert.Equal(t, MockSubmitKeyRegistrationErr, err)
 
-	_, err = p.LoadIdentity(testUuid)
-	assert.Equal(t, r.ErrNotExist, err)
+	initialized, err := p.IsInitialized(testUuid)
+	require.NoError(t, err)
+	assert.False(t, initialized)
 }
 
 func TestIdentityHandler_InitIdentity_BadSubmitCSR(t *testing.T) {

--- a/main/adapters/repository/key_cache.go
+++ b/main/adapters/repository/key_cache.go
@@ -70,3 +70,8 @@ func (k *KeyCache) PublicKeyExists(id uuid.UUID) (bool, error) {
 	_, found := k.publicKeyCache.Load(id)
 	return found, nil
 }
+
+func (k *KeyCache) ClearKeypair(id uuid.UUID) {
+	k.publicKeyCache.Delete(id)
+	k.privateKeyCache.Delete(id)
+}

--- a/main/adapters/repository/protocol.go
+++ b/main/adapters/repository/protocol.go
@@ -106,6 +106,10 @@ func (p *ExtendedProtocol) StoreIdentity(tx TransactionCtx, i ent.Identity) erro
 	return p.ContextManager.StoreIdentity(tx, i)
 }
 
+func (p *ExtendedProtocol) ClearKeysFromCache(uid uuid.UUID) {
+	p.keyCache.ClearKeypair(uid)
+}
+
 func (p *ExtendedProtocol) LoadIdentity(uid uuid.UUID) (*ent.Identity, error) {
 	i, err := p.ContextManager.LoadIdentity(uid)
 	if err != nil {


### PR DESCRIPTION
**FIXED:**

- fixed bug caused by cached keys after failed key registration causing subsequent identity registration attempts to fail with error `409` - `identity already registered`