### PR TITLE
PROJ-97 configurable timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,24 @@ By default, the log of the client is in JSON format. To change it to a (more hum
     UBIRCH_LOGTEXTFORMAT=true
     ```
 
+### Request Timeouts
+
+The following request-related timeouts can be configured.
+
+| json                       | env                           | description                                                                                          | default value |
+|----------------------------|-------------------------------|------------------------------------------------------------------------------------------------------|---------------|
+| `identityServiceTimeoutMs` | `IDENTITY_SERVICE_TIMEOUT_MS` | time limit for requests to the UBIRCH identity service in milliseconds                               | 10000         |
+| `authServiceTimeoutMs`     | `AUTH_SERVICE_TIMEOUT_MS`     | time limit for requests to the UBIRCH authentication service (niomon) in milliseconds                | 2000          |
+| `verifyServiceTimeoutMs`   | `VERIFY_SERVICE_TIMEOUT_MS`   | time limit for requests to the UBIRCH verification service in milliseconds                           | 600           |
+| `verificationTimeoutMs`    | `VERIFICATION_TIMEOUT_MS`     | time limit for repeated attempts to verify a hash at the UBIRCH verification service in milliseconds | 2000          |
+
+_If a hash can not be verified by the UBIRCH verification service, a possible reason is that the verification was
+attempted too early after anchoring and that a subsequent request will be successful. Because of this, the client
+retries the verification if it fails with an HTTP response code `404`._
+
+- _`verifyServiceTimeoutMs` is the HTTP client timeout for each individual request to the verification service_
+- _`verificationTimeoutMs` is the max. duration that verification will be attempted repeatedly_
+
 ## Legacy file-based context migration
 
 In version 1 of the client, the context has been stored in files. In order to use a newer version, the context can be

--- a/main/adapters/clients/ubirch_authentication_client.go
+++ b/main/adapters/clients/ubirch_authentication_client.go
@@ -16,6 +16,8 @@ package clients
 
 import (
 	"encoding/base64"
+	"net/http"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,14 +27,15 @@ import (
 )
 
 type AuthenticationServiceClient struct {
-	AuthServiceURL string
+	AuthServiceURL     string
+	AuthServiceTimeout time.Duration
 }
 
 func (c *AuthenticationServiceClient) SendToAuthService(uid uuid.UUID, auth string, upp []byte) (h.HTTPResponse, error) {
 	timer := prometheus.NewTimer(prom.UpstreamResponseDuration)
 	defer timer.ObserveDuration()
 
-	return Post(c.AuthServiceURL, upp, ubirchHeader(uid, auth))
+	return sendRequest(http.MethodPost, c.AuthServiceURL, upp, ubirchHeader(uid, auth), c.AuthServiceTimeout)
 }
 
 func ubirchHeader(uid uuid.UUID, auth string) map[string]string {

--- a/main/adapters/clients/ubirch_identity_client.go
+++ b/main/adapters/clients/ubirch_identity_client.go
@@ -18,9 +18,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/ubirch/ubirch-protocol-go/ubirch/v2"
@@ -31,8 +32,9 @@ import (
 )
 
 type IdentityServiceClient struct {
-	KeyServiceURL      string
-	IdentityServiceURL string
+	KeyServiceURL          string
+	IdentityServiceURL     string
+	IdentityServiceTimeout time.Duration
 }
 
 // RequestPublicKeys requests a devices public keys at the identity service
@@ -55,11 +57,11 @@ func (c *IdentityServiceClient) RequestPublicKeys(id uuid.UUID) ([]ubirch.Signed
 	}
 
 	if h.HttpFailed(resp.StatusCode) {
-		respContent, _ := ioutil.ReadAll(resp.Body)
+		respContent, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("retrieving public key info from %s failed: (%s) %s", url, resp.Status, string(respContent))
 	}
 
-	respBodyBytes, err := ioutil.ReadAll(resp.Body)
+	respBodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read response body: %v", err)
 	}
@@ -94,7 +96,7 @@ func (c *IdentityServiceClient) SubmitKeyRegistration(uid uuid.UUID, cert []byte
 
 	keyRegHeader := map[string]string{"content-type": "application/json"}
 
-	resp, err := Post(c.KeyServiceURL, cert, keyRegHeader)
+	resp, err := sendRequest(http.MethodPost, c.KeyServiceURL, cert, keyRegHeader, c.IdentityServiceTimeout)
 	if err != nil {
 		return fmt.Errorf("error sending key registration: %v", err)
 	}
@@ -110,7 +112,7 @@ func (c *IdentityServiceClient) RequestKeyDeletion(uid uuid.UUID, cert []byte) e
 
 	keyDelHeader := map[string]string{"content-type": "application/json"}
 
-	resp, err := Delete(c.KeyServiceURL, cert, keyDelHeader)
+	resp, err := sendRequest(http.MethodDelete, c.KeyServiceURL, cert, keyDelHeader, c.IdentityServiceTimeout)
 	if err != nil {
 		return fmt.Errorf("error sending key deletion request: %v", err)
 	}
@@ -121,13 +123,13 @@ func (c *IdentityServiceClient) RequestKeyDeletion(uid uuid.UUID, cert []byte) e
 	return nil
 }
 
-// SubmitCSR submits a X.509 Certificate Signing Request for the public key to the identity service
+// SubmitCSR submits an X.509 Certificate Signing Request for the public key to the identity service
 func (c *IdentityServiceClient) SubmitCSR(uid uuid.UUID, csr []byte) error {
 	log.Debugf("%s: submitting CSR to identity service", uid)
 
 	CSRHeader := map[string]string{"content-type": "application/octet-stream"}
 
-	resp, err := Post(c.IdentityServiceURL, csr, CSRHeader)
+	resp, err := sendRequest(http.MethodPost, c.IdentityServiceURL, csr, CSRHeader, c.IdentityServiceTimeout)
 	if err != nil {
 		return fmt.Errorf("error sending CSR: %v", err)
 	}

--- a/main/adapters/clients/ubirch_service_client.go
+++ b/main/adapters/clients/ubirch_service_client.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,9 +18,10 @@ type UbirchServiceClient struct {
 }
 
 func sendRequest(method string, serviceURL string, data []byte, header map[string]string, timeout time.Duration) (h.HTTPResponse, error) {
-	client := &http.Client{Timeout: timeout}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
-	req, err := http.NewRequest(method, serviceURL, bytes.NewBuffer(data))
+	req, err := http.NewRequestWithContext(ctx, method, serviceURL, bytes.NewBuffer(data))
 	if err != nil {
 		return h.HTTPResponse{}, fmt.Errorf("can't make new post request: %v", err)
 	}
@@ -28,7 +30,7 @@ func sendRequest(method string, serviceURL string, data []byte, header map[strin
 		req.Header.Set(k, v)
 	}
 
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return h.HTTPResponse{}, err
 	}

--- a/main/adapters/clients/ubirch_service_client.go
+++ b/main/adapters/clients/ubirch_service_client.go
@@ -3,8 +3,9 @@ package clients
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"time"
 
 	h "github.com/ubirch/ubirch-client-go/main/adapters/http_server"
 )
@@ -15,18 +16,8 @@ type UbirchServiceClient struct {
 	VerificationServiceClient
 }
 
-// Post submits a message to a backend service
-// returns the response or encountered errors
-func Post(serviceURL string, data []byte, header map[string]string) (h.HTTPResponse, error) {
-	return sendRequest(http.MethodPost, serviceURL, data, header)
-}
-
-func Delete(serviceURL string, data []byte, header map[string]string) (h.HTTPResponse, error) {
-	return sendRequest(http.MethodDelete, serviceURL, data, header)
-}
-
-func sendRequest(method string, serviceURL string, data []byte, header map[string]string) (h.HTTPResponse, error) {
-	client := &http.Client{Timeout: h.BackendRequestTimeout}
+func sendRequest(method string, serviceURL string, data []byte, header map[string]string, timeout time.Duration) (h.HTTPResponse, error) {
+	client := &http.Client{Timeout: timeout}
 
 	req, err := http.NewRequest(method, serviceURL, bytes.NewBuffer(data))
 	if err != nil {
@@ -45,7 +36,7 @@ func sendRequest(method string, serviceURL string, data []byte, header map[strin
 	//noinspection GoUnhandledErrorResult
 	defer resp.Body.Close()
 
-	respBodyBytes, err := ioutil.ReadAll(resp.Body)
+	respBodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return h.HTTPResponse{}, err
 	}

--- a/main/adapters/clients/ubirch_verification_client.go
+++ b/main/adapters/clients/ubirch_verification_client.go
@@ -15,13 +15,18 @@
 package clients
 
 import (
+	"net/http"
+	"time"
+
 	h "github.com/ubirch/ubirch-client-go/main/adapters/http_server"
 )
 
 type VerificationServiceClient struct {
-	VerifyServiceURL string
+	VerifyServiceURL     string
+	VerifyServiceTimeout time.Duration
 }
 
 func (c *VerificationServiceClient) RequestHash(hashBase64 string) (h.HTTPResponse, error) {
-	return Post(c.VerifyServiceURL, []byte(hashBase64), map[string]string{"content-type": "text/plain"})
+	return sendRequest(http.MethodPost, c.VerifyServiceURL, []byte(hashBase64),
+		map[string]string{"content-type": "text/plain"}, c.VerifyServiceTimeout)
 }

--- a/main/adapters/handlers/signer.go
+++ b/main/adapters/handlers/signer.go
@@ -169,7 +169,7 @@ func (s *Signer) sendUPP(msg h.HTTPRequest, upp []byte, pub []byte) h.HTTPRespon
 	backendResp, err := s.SendToAuthService(msg.ID, msg.Auth, upp)
 	if err != nil {
 		if os.IsTimeout(err) {
-			log.Errorf("%s: request to UBIRCH Authentication Service timed out after %s: %v", msg.ID, h.BackendRequestTimeout.String(), err)
+			log.Errorf("%s: request to UBIRCH Authentication Service timed out: %v", msg.ID, err)
 			return errorResponse(http.StatusGatewayTimeout, "")
 		} else {
 			log.Errorf("%s: sending request to UBIRCH Authentication Service failed: %v", msg.ID, err)

--- a/main/adapters/handlers/verifier.go
+++ b/main/adapters/handlers/verifier.go
@@ -51,6 +51,7 @@ type Verifier struct {
 	RequestHash                   func(hashBase64 string) (h.HTTPResponse, error)
 	RequestPublicKeys             func(id uuid.UUID) ([]ubirch.SignedKeyRegistration, error)
 	VerifyFromKnownIdentitiesOnly bool
+	VerificationTimeout           time.Duration
 }
 
 func (v *Verifier) Verify(hash []byte) h.HTTPResponse {
@@ -102,7 +103,7 @@ func (v *Verifier) loadUPP(hash []byte) (int, []byte, error) {
 	hashBase64 := base64.StdEncoding.EncodeToString(hash)
 
 	n := 0
-	for stay, timeout := true, time.After(h.VerificationTimeout); stay; {
+	for stay, timeout := true, time.After(v.VerificationTimeout); stay; {
 		n++
 		select {
 		case <-timeout:

--- a/main/adapters/handlers/verifier.go
+++ b/main/adapters/handlers/verifier.go
@@ -121,7 +121,7 @@ func (v *Verifier) loadUPP(ctx context.Context, hash []byte) (int, []byte, error
 					return http.StatusBadGateway, nil, fmt.Errorf("sending request to UBIRCH Verification Service failed: %v", err)
 				}
 			}
-			stay = h.HttpFailed(resp.StatusCode)
+			stay = resp.StatusCode == http.StatusNotFound
 			if stay {
 				log.Debugf("Couldn't verify hash yet (%d). Retry... %d", resp.StatusCode, n)
 				time.Sleep(200 * time.Millisecond)

--- a/main/adapters/handlers/verifier.go
+++ b/main/adapters/handlers/verifier.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/google/uuid"
@@ -114,7 +115,11 @@ func (v *Verifier) loadUPP(ctx context.Context, hash []byte) (int, []byte, error
 		default:
 			resp, err = v.RequestHash(hashBase64)
 			if err != nil {
-				return http.StatusBadGateway, nil, fmt.Errorf("error sending verification request: %v", err)
+				if os.IsTimeout(err) {
+					return http.StatusGatewayTimeout, nil, fmt.Errorf("request to UBIRCH Verification Service timed out: %v", err)
+				} else {
+					return http.StatusBadGateway, nil, fmt.Errorf("sending request to UBIRCH Verification Service failed: %v", err)
+				}
 			}
 			stay = h.HttpFailed(resp.StatusCode)
 			if stay {

--- a/main/adapters/http_server/common.go
+++ b/main/adapters/http_server/common.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/go-chi/chi"
 	"github.com/google/uuid"
@@ -19,14 +18,6 @@ import (
 )
 
 const (
-	BackendRequestTimeout = 15 * time.Second        // time after which requests to the ubirch backend will be canceled
-	VerificationTimeout   = 1500 * time.Millisecond // max time to attempt to verify hashes at the verification service
-	GatewayTimeout        = 45 * time.Second        // time after which a 504 response will be sent if no timely response could be produced
-	ShutdownTimeout       = 25 * time.Second        // time after which the server will be shut down forcefully if graceful shutdown did not happen before
-	ReadTimeout           = 1 * time.Second         // maximum duration for reading the entire request -> low since we only expect requests with small content
-	WriteTimeout          = 60 * time.Second        // time after which the connection will be closed if response was not written -> this should never happen
-	IdleTimeout           = 60 * time.Second        // time to wait for the next request when keep-alives are enabled
-
 	UUIDKey                = "uuid"
 	VerifyPath             = "/verify"
 	OfflinePath            = "/offline"

--- a/main/adapters/http_server/verification_service.go
+++ b/main/adapters/http_server/verification_service.go
@@ -1,6 +1,7 @@
 package http_server
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -8,7 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type Verify func([]byte) HTTPResponse
+type Verify func(context.Context, []byte) HTTPResponse
 type VerifyOffline func([]byte, []byte) HTTPResponse
 
 type VerificationService struct {
@@ -18,6 +19,8 @@ type VerificationService struct {
 
 func (s *VerificationService) HandleRequest(offline, isHashRequest bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
 		var resp HTTPResponse
 
 		if offline {
@@ -38,10 +41,9 @@ func (s *VerificationService) HandleRequest(offline, isHashRequest bool) http.Ha
 				return
 			}
 
-			resp = s.Verify(hash[:])
+			resp = s.Verify(ctx, hash[:])
 		}
 
-		ctx := r.Context()
 		select {
 		case <-ctx.Done():
 			log.Warnf("verification response could not be sent: http request %s", ctx.Err())

--- a/main/config/config.go
+++ b/main/config/config.go
@@ -60,7 +60,7 @@ const (
 	defaultGatewayTimeoutMs         = 10_000
 	defaultIdentityServiceTimeoutMs = 10_000 // should be high since we want to avoid canceling an otherwise successful key registration
 	defaultAuthServiceTimeoutMs     = 2_000
-	defaultVerifyServiceTimeoutMs   = 500
+	defaultVerifyServiceTimeoutMs   = 600
 	defaultVerificationTimeoutMs    = 2_000
 )
 

--- a/main/config/config.go
+++ b/main/config/config.go
@@ -56,41 +56,52 @@ const (
 	defaultKeyDerivationParamParallelism = 1
 	defaultKeyDerivationKeyLen           = 32
 	defaultKeyDerivationSaltLen          = 16
+
+	defaultGatewayTimeoutMs         = 10_000
+	defaultIdentityServiceTimeoutMs = 10_000 // should be high since we want to avoid canceling an otherwise successful key registration
+	defaultAuthServiceTimeoutMs     = 2_000
+	defaultVerifyServiceTimeoutMs   = 500
+	defaultVerificationTimeoutMs    = 2_000
 )
 
 var IsDevelopment bool
 
 type Config struct {
-	Devices            map[string]string `json:"devices"`                                             // maps UUIDs to backend auth tokens
-	Secret16Base64     string            `json:"secret" envconfig:"secret"`                           // LEGACY: 16 bytes secret used to encrypt the key store (mandatory only for migration)
-	Secret32Base64     string            `json:"secret32" envconfig:"secret32"`                       // 32 byte secret used to encrypt the key store (mandatory)
-	RegisterAuth       string            `json:"registerAuth"`                                        // auth token needed for new identity registration
-	Env                string            `json:"env"`                                                 // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
-	PostgresDSN        string            `json:"postgresDSN" envconfig:"POSTGRES_DSN"`                // data source name for postgres database
-	SqliteDSN          string            `json:"sqliteDSN" envconfig:"SQLITE_DSN"`                    // path to the sqlite db file
-	DbMaxConns         int               `json:"dbMaxConns" envconfig:"DB_MAX_CONNS"`                 // maximum number of open connections to the database
-	TCP_addr           string            `json:"TCP_addr"`                                            // the TCP address for the server to listen on, in the form "host:port", defaults to ":8080"
-	TLS                bool              `json:"TLS"`                                                 // enable serving HTTPS endpoints, defaults to 'false'
-	TLS_CertFile       string            `json:"TLSCertFile"`                                         // filename of TLS certificate file name, defaults to "cert.pem"
-	TLS_KeyFile        string            `json:"TLSKeyFile"`                                          // filename of TLS key file name, defaults to "key.pem"
-	CORS               bool              `json:"CORS"`                                                // enable CORS, defaults to 'false'
-	CORS_Origins       []string          `json:"CORS_origins"`                                        // list of allowed origin hosts, defaults to ["*"]
-	CSR_Country        string            `json:"CSR_country"`                                         // subject country for public key Certificate Signing Requests
-	CSR_Organization   string            `json:"CSR_organization"`                                    // subject organization for public key Certificate Signing Requests
-	Debug              bool              `json:"debug"`                                               // enable extended debug output, defaults to 'false'
-	LogTextFormat      bool              `json:"logTextFormat"`                                       // log in text format for better human readability, default format is JSON
-	KdMaxTotalMemMiB   uint32            `json:"kdMaxTotalMemMiB" envconfig:"KD_MAX_TOTAL_MEM_MIB"`   // maximal total memory to use for key derivation at a time in MiB
-	KdParamMemMiB      uint32            `json:"kdParamMemMiB" envconfig:"KD_PARAM_MEM_MIB"`          // memory parameter for key derivation, specifies the size of the memory in MiB
-	KdParamTime        uint32            `json:"kdParamTime" envconfig:"KD_PARAM_TIME"`               // time parameter for key derivation, specifies the number of passes over the memory
-	KdParamParallelism uint8             `json:"kdParamParallelism" envconfig:"KD_PARAM_PARALLELISM"` // parallelism (threads) parameter for key derivation, specifies the number of threads and can be adjusted to the number of available CPUs
-	KdParamKeyLen      uint32            `json:"kdParamKeyLen" envconfig:"KD_PARAM_KEY_LEN"`          // key length parameter for key derivation, specifies the length of the resulting key in bytes
-	KdParamSaltLen     uint32            `json:"kdParamSaltLen" envconfig:"KD_PARAM_SALT_LEN"`        // salt length parameter for key derivation, specifies the length of the random salt in bytes
-	KdUpdateParams     bool              `json:"kdUpdateParams" envconfig:"KD_UPDATE_PARAMS"`         // update key derivation parameters of already existing password hashes
-	KeyService         string            // key service URL (set automatically)
-	IdentityService    string            // identity service URL (set automatically)
-	Niomon             string            // authentication service URL (set automatically)
-	VerifyService      string            // verification service URL (set automatically)
-	SecretBytes32      []byte            // the decoded 32 byte key store secret for database (set automatically)
+	Devices                  map[string]string `json:"devices"`                                                          // maps UUIDs to backend auth tokens
+	Secret16Base64           string            `json:"secret" envconfig:"secret"`                                        // LEGACY: 16 bytes secret used to encrypt the key store (mandatory only for migration)
+	Secret32Base64           string            `json:"secret32" envconfig:"secret32"`                                    // 32 byte secret used to encrypt the key store (mandatory)
+	RegisterAuth             string            `json:"registerAuth"`                                                     // auth token needed for new identity registration
+	Env                      string            `json:"env"`                                                              // the ubirch backend environment [dev, demo, prod], defaults to 'prod'
+	PostgresDSN              string            `json:"postgresDSN" envconfig:"POSTGRES_DSN"`                             // data source name for postgres database
+	SqliteDSN                string            `json:"sqliteDSN" envconfig:"SQLITE_DSN"`                                 // path to the sqlite db file
+	DbMaxConns               int               `json:"dbMaxConns" envconfig:"DB_MAX_CONNS"`                              // maximum number of open connections to the database
+	TCP_addr                 string            `json:"TCP_addr"`                                                         // the TCP address for the server to listen on, in the form "host:port", defaults to ":8080"
+	TLS                      bool              `json:"TLS"`                                                              // enable serving HTTPS endpoints, defaults to 'false'
+	TLS_CertFile             string            `json:"TLSCertFile"`                                                      // filename of TLS certificate file name, defaults to "cert.pem"
+	TLS_KeyFile              string            `json:"TLSKeyFile"`                                                       // filename of TLS key file name, defaults to "key.pem"
+	CORS                     bool              `json:"CORS"`                                                             // enable CORS, defaults to 'false'
+	CORS_Origins             []string          `json:"CORS_origins"`                                                     // list of allowed origin hosts, defaults to ["*"]
+	CSR_Country              string            `json:"CSR_country"`                                                      // subject country for public key Certificate Signing Requests
+	CSR_Organization         string            `json:"CSR_organization"`                                                 // subject organization for public key Certificate Signing Requests
+	Debug                    bool              `json:"debug"`                                                            // enable extended debug output, defaults to 'false'
+	LogTextFormat            bool              `json:"logTextFormat"`                                                    // log in text format for better human readability, default format is JSON
+	KdMaxTotalMemMiB         uint32            `json:"kdMaxTotalMemMiB" envconfig:"KD_MAX_TOTAL_MEM_MIB"`                // maximal total memory to use for key derivation at a time in MiB
+	KdParamMemMiB            uint32            `json:"kdParamMemMiB" envconfig:"KD_PARAM_MEM_MIB"`                       // memory parameter for key derivation, specifies the size of the memory in MiB
+	KdParamTime              uint32            `json:"kdParamTime" envconfig:"KD_PARAM_TIME"`                            // time parameter for key derivation, specifies the number of passes over the memory
+	KdParamParallelism       uint8             `json:"kdParamParallelism" envconfig:"KD_PARAM_PARALLELISM"`              // parallelism (threads) parameter for key derivation, specifies the number of threads and can be adjusted to the number of available CPUs
+	KdParamKeyLen            uint32            `json:"kdParamKeyLen" envconfig:"KD_PARAM_KEY_LEN"`                       // key length parameter for key derivation, specifies the length of the resulting key in bytes
+	KdParamSaltLen           uint32            `json:"kdParamSaltLen" envconfig:"KD_PARAM_SALT_LEN"`                     // salt length parameter for key derivation, specifies the length of the random salt in bytes
+	KdUpdateParams           bool              `json:"kdUpdateParams" envconfig:"KD_UPDATE_PARAMS"`                      // update key derivation parameters of already existing password hashes
+	GatewayTimeoutMs         int64             `json:"gatewayTimeoutMs" envconfig:"GATEWAY_TIMEOUT_MS"`                  // time after which a request will be cancelled and a 504 Gateway Timeout error will be sent to the client if no timely response could be produced
+	IdentityServiceTimeoutMs int64             `json:"identityServiceTimeoutMs" envconfig:"IDENTITY_SERVICE_TIMEOUT_MS"` // time limit for requests to the ubirch identity service in milliseconds
+	AuthServiceTimeoutMs     int64             `json:"authServiceTimeoutMs" envconfig:"AUTH_SERVICE_TIMEOUT_MS"`         // time limit for requests to the ubirch authentication service (niomon) in milliseconds
+	VerifyServiceTimeoutMs   int64             `json:"verifyServiceTimeoutMs" envconfig:"VERIFY_SERVICE_TIMEOUT_MS"`     // time limit for requests to the ubirch verification service in milliseconds
+	VerificationTimeoutMs    int64             `json:"verificationTimeoutMs" envconfig:"VERIFICATION_TIMEOUT_MS"`        // time limit for repeated attempts to verify a hash at the ubirch verification service in milliseconds
+	KeyService               string            // key service URL (set automatically)
+	IdentityService          string            // identity service URL (set automatically)
+	Niomon                   string            // authentication service URL (set automatically)
+	VerifyService            string            // verification service URL (set automatically)
+	SecretBytes32            []byte            // the decoded 32 byte key store secret for database (set automatically)
 }
 
 func (c *Config) Load(configDir, filename string) error {
@@ -135,6 +146,7 @@ func (c *Config) Load(configDir, filename string) error {
 	c.setDefaultCORS()
 	c.setDefaultSQLite(configDir)
 	c.setKeyDerivationParams()
+	c.setDefaultTimeouts()
 	return c.setDefaultURLs()
 }
 
@@ -256,6 +268,28 @@ func (c *Config) setKeyDerivationParams() {
 
 	if c.KdParamSaltLen == 0 {
 		c.KdParamSaltLen = defaultKeyDerivationSaltLen
+	}
+}
+
+func (c *Config) setDefaultTimeouts() {
+	if c.GatewayTimeoutMs == 0 {
+		c.GatewayTimeoutMs = defaultGatewayTimeoutMs
+	}
+
+	if c.IdentityServiceTimeoutMs == 0 {
+		c.IdentityServiceTimeoutMs = defaultIdentityServiceTimeoutMs
+	}
+
+	if c.AuthServiceTimeoutMs == 0 {
+		c.AuthServiceTimeoutMs = defaultAuthServiceTimeoutMs
+	}
+
+	if c.VerifyServiceTimeoutMs == 0 {
+		c.VerifyServiceTimeoutMs = defaultVerifyServiceTimeoutMs
+	}
+
+	if c.VerificationTimeoutMs == 0 {
+		c.VerificationTimeoutMs = defaultVerificationTimeoutMs
 	}
 }
 

--- a/main/config/config_test.go
+++ b/main/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const expectedConfig = `{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","secret32":"VsCwmGssk7Ho2APyq1reGAKkB/+e8GlRfhM3NbYQWPU=","registerAuth":"test123","env":"","postgresDSN":"","sqliteDSN":"","dbMaxConns":0,"TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"kdParamKeyLen":0,"kdParamSaltLen":0,"kdUpdateParams":false,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":"","SecretBytes32":null}`
+const expectedConfig = `{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","secret32":"VsCwmGssk7Ho2APyq1reGAKkB/+e8GlRfhM3NbYQWPU=","registerAuth":"test123","env":"","postgresDSN":"","sqliteDSN":"","dbMaxConns":0,"TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"kdParamKeyLen":0,"kdParamSaltLen":0,"kdUpdateParams":false,"gatewayTimeoutMs":0,"identityServiceTimeoutMs":0,"authServiceTimeoutMs":0,"verifyServiceTimeoutMs":0,"verificationTimeoutMs":0,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":"","SecretBytes32":null}`
 
 func TestConfig(t *testing.T) {
 	configBytes := []byte(expectedConfig)

--- a/main/main.go
+++ b/main/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/ubirch/ubirch-client-go/main/adapters/clients"
 	"github.com/ubirch/ubirch-client-go/main/adapters/handlers"
@@ -104,8 +105,11 @@ func main() {
 	client := &clients.UbirchServiceClient{}
 	client.KeyServiceURL = conf.KeyService
 	client.IdentityServiceURL = conf.IdentityService
+	client.IdentityServiceTimeout = time.Duration(conf.IdentityServiceTimeoutMs) * time.Millisecond
 	client.AuthServiceURL = conf.Niomon
+	client.AuthServiceTimeout = time.Duration(conf.AuthServiceTimeoutMs) * time.Millisecond
 	client.VerifyServiceURL = conf.VerifyService
+	client.VerifyServiceTimeout = time.Duration(conf.VerifyServiceTimeoutMs) * time.Millisecond
 
 	idHandler := &handlers.IdentityHandler{
 		Protocol:              protocol,
@@ -131,6 +135,7 @@ func main() {
 		RequestHash:                   client.RequestHash,
 		RequestPublicKeys:             client.RequestPublicKeys,
 		VerifyFromKnownIdentitiesOnly: false, // TODO: make configurable
+		VerificationTimeout:           time.Duration(conf.VerificationTimeoutMs) * time.Millisecond,
 	}
 
 	// set up HTTP server


### PR DESCRIPTION
**Changed:**

- individually configurable HTTP client timeouts for requests to upstream servers
  - `identityServiceTimeoutMs`
  - `authServiceTimeoutMs`
  - `verifyServiceTimeoutMs`
- configurable timeout for repeated verification attempts `verificationTimeoutMs`