### PR TITLE
UC-1555 explicit db config

### DIFF
--- a/main/adapters/repository/context_manager.go
+++ b/main/adapters/repository/context_manager.go
@@ -39,9 +39,5 @@ type TransactionCtx interface {
 }
 
 func GetContextManager(c *config.Config) (ContextManager, error) {
-	if c.PostgresDSN != "" {
-		return NewDatabaseManager(PostgreSQL, c.PostgresDSN, c.DbMaxConns)
-	} else {
-		return NewDatabaseManager(SQLite, c.SqliteDSN, c.DbMaxConns)
-	}
+	return NewDatabaseManager(c.DbDriver, c.DbDSN, c.DbMaxConns)
 }

--- a/main/adapters/repository/context_manager_test.go
+++ b/main/adapters/repository/context_manager_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,12 +10,9 @@ import (
 )
 
 func TestGetContextManagerDB(t *testing.T) {
-	dbConf, err := getConfig()
-	require.NoError(t, err)
-
 	conf := &config.Config{
-		PostgresDSN: dbConf.PostgresDSN,
-		DbMaxConns:  dbConf.DbMaxConns,
+		DbDriver: SQLite,
+		DbDSN:    filepath.Join(t.TempDir(), testSQLiteDSN),
 	}
 
 	ContextMngr, err := GetContextManager(conf)

--- a/main/adapters/repository/database_test.go
+++ b/main/adapters/repository/database_test.go
@@ -461,7 +461,7 @@ func TestDatabaseManager_RecoverUndefinedTable(t *testing.T) {
 	c, err := getConfig()
 	require.NoError(t, err)
 
-	pg, err := sql.Open(PostgreSQL, c.PostgresDSN)
+	pg, err := sql.Open(PostgreSQL, c.DbDSN)
 	require.NoError(t, err)
 
 	dm := &DatabaseManager{
@@ -478,7 +478,7 @@ func TestDatabaseManager_Retry(t *testing.T) {
 	c, err := getConfig()
 	require.NoError(t, err)
 
-	dm, err := NewDatabaseManager(PostgreSQL, c.PostgresDSN, 101)
+	dm, err := NewDatabaseManager(PostgreSQL, c.DbDSN, 101)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
 
@@ -515,7 +515,7 @@ func getConfig() (*config.Config, error) {
 			"Please provide a configuration file \"%s\" in the main directory which contains\n"+
 			"a DSN for a postgres database in order to test the database context management.\n\n"+
 			"!!! THIS MUST BE DIFFERENT FROM THE DSN USED FOR THE ACTUAL CONTEXT !!!\n\n"+
-			"{\n\t\"postgresDSN\": \"postgres://<username>:<password>@<hostname>:5432/<TEST-database>\"\n}\n"+
+			"{\n\t\"dbDSN\": \"postgres://<username>:<password>@<hostname>:5432/<TEST-database>\"\n}\n"+
 			"--------------------------------------------------------------------------------",
 			err, configFileName)
 	}
@@ -530,6 +530,10 @@ func getConfig() (*config.Config, error) {
 		return nil, err
 	}
 
+	if len(c.DbDSN) == 0 {
+		return nil, fmt.Errorf("missing DSN for test postgres database ('dbDSN') in configuration %s", configFileName)
+	}
+
 	return c, nil
 }
 
@@ -539,7 +543,7 @@ func initDB(maxConns int) (*DatabaseManager, error) {
 		return nil, err
 	}
 
-	return NewDatabaseManager(PostgreSQL, c.PostgresDSN, maxConns)
+	return NewDatabaseManager(PostgreSQL, c.DbDSN, maxConns)
 }
 
 func cleanUpDB(t assert.TestingT, dm *DatabaseManager) {

--- a/main/adapters/repository/migrator_test.go
+++ b/main/adapters/repository/migrator_test.go
@@ -32,15 +32,16 @@ func TestMigrate(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				c.PostgresDSN = dbConf.PostgresDSN
-				c.DbMaxConns = dbConf.DbMaxConns
+				c.DbDriver = PostgreSQL
+				c.DbDSN = dbConf.DbDSN
 				return nil
 			},
 		},
 		{
 			name: "sqlite migration",
 			setDSN: func(c *config.Config, configDir string) error {
-				c.SqliteDSN = filepath.Join(configDir, testSQLiteDSN)
+				c.DbDriver = SQLite
+				c.DbDSN = filepath.Join(configDir, testSQLiteDSN)
 				return nil
 			},
 		},

--- a/main/config/config_test.go
+++ b/main/config/config_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-const expectedConfig = `{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","secret32":"VsCwmGssk7Ho2APyq1reGAKkB/+e8GlRfhM3NbYQWPU=","registerAuth":"test123","env":"","postgresDSN":"","sqliteDSN":"","dbMaxConns":0,"TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"kdParamKeyLen":0,"kdParamSaltLen":0,"kdUpdateParams":false,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":"","SecretBytes32":null}`
+const expectedConfig = `{"devices":null,"secret":"MTIzNDU2Nzg5MDU2Nzg5MA==","secret32":"VsCwmGssk7Ho2APyq1reGAKkB/+e8GlRfhM3NbYQWPU=","registerAuth":"test123","env":"","dbDriver":"","dbDSN":"","dbMaxConns":0,"TCP_addr":"","TLS":false,"TLSCertFile":"","TLSKeyFile":"","CORS":false,"CORS_origins":null,"CSR_country":"","CSR_organization":"","debug":false,"logTextFormat":false,"kdMaxTotalMemMiB":0,"kdParamMemMiB":0,"kdParamTime":0,"kdParamParallelism":0,"kdParamKeyLen":0,"kdParamSaltLen":0,"kdUpdateParams":false,"KeyService":"","IdentityService":"","Niomon":"","VerifyService":"","SecretBytes32":null}`
 
 func TestConfig(t *testing.T) {
 	configBytes := []byte(expectedConfig)

--- a/main/config/example.env
+++ b/main/config/example.env
@@ -1,6 +1,7 @@
 UBIRCH_SECRET32=sdSjtMh6C2oNgsiVcPx89RgcNYl8L6R9PhWU3iGIL+k=
 UBIRCH_REGISTERAUTH=qlJIjT2asJD23Y7toZczJriPTXd0GAmFUYAjHl0PcnA=
-UBIRCH_POSTGRES_DSN=postgres://<username>:<password>@<hostname>:5432/<database>
+UBIRCH_DB_DRIVER=postgres
+UBIRCH_DB_DSN=postgres://<username>:<password>@<hostname>:5432/<database>
 UBIRCH_DB_MAX_CONNS=20
 UBIRCH_DEVICES=b07c32c6-4525-43f8-ab94-9383bf585ef0:ad3e073b-9ead-437c-9e09-853e9a508dca,e1aead08-1fcb-47b3-bf2c-d3343cb979da:cefa0c34-8448-44f2-9330-27c66519a2d3,8a70ad8b-a564-4e58-9a3b-224ac0f0153f:f728ddb3-d504-4925-b216-b7842a2f1a6b
 UBIRCH_ENV=prod

--- a/main/config/example_config.json
+++ b/main/config/example_config.json
@@ -1,7 +1,8 @@
 {
   "secret32": "sdSjtMh6C2oNgsiVcPx89RgcNYl8L6R9PhWU3iGIL+k=",
   "registerAuth": "qlJIjT2asJD23Y7toZczJriPTXd0GAmFUYAjHl0PcnA=",
-  "postgresDSN": "postgres://<username>:<password>@<hostname>:5432/<database>",
+  "dbDriver": "postgres",
+  "dbDSN": "postgres://<username>:<password>@<hostname>:5432/<database>",
   "dbMaxConns": 20,
   "devices": {
     "b07c32c6-4525-43f8-ab94-9383bf585ef0": "ad3e073b-9ead-437c-9e09-853e9a508dca",

--- a/main/go.sum
+++ b/main/go.sum
@@ -224,7 +224,6 @@ github.com/ubirch/go.crypto v0.1.2 h1:IYMOx19UgWt4+k7PydcOVtEWFiU10O8dHoof00j8IK
 github.com/ubirch/go.crypto v0.1.2/go.mod h1:aiZQ37CxSBS7cBLsFbTnDxGeg5RkH7Z5LKBYeNasIrw=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20220930133231-a5f175fc85ef h1:MlLicaE95wOsS3ivwimQrpIhwG7xrn8toVChmlwwy08=
 github.com/ubirch/ubirch-protocol-go/ubirch/v2 v2.2.6-0.20220930133231-a5f175fc85ef/go.mod h1:85/1vY7PNajuIwkC9Qd2cs+AT3YBgs416FXocbdHE4k=
-github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=


### PR DESCRIPTION
**Changed:**

- added explicit database driver selection to configuration
  - `config.json`:
    ```json
      "dbDriver": "<postgres | sqlite>",
      "dbDSN": "<data source name for database>",
    ```
  -  env:
      ```console
      UBIRCH_DB_DRIVER=<postgres | sqlite>
      UBIRCH_DB_DSN=<data source name for database>
      ```

**Removed:**

- removed implicit postgres and sqlite configuration
  - `config.json`:
    ```json
      "postgresDSN": "<data source name for postgres database>",
      "sqliteDSN": "<filename for sqlite database file>",
    ```
  -  env:
      ```console
      UBIRCH_POSTGRES_DSN=<data source name for postgres database>
      UBIRCH_SQLITE_DSN=<filename for sqlite database file>
      ```