### PR TITLE
UC-1620 integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ main/main
 /main/protocol.json
 /main/identities.json
 /load-test/config.json
+/integration-test/config.json

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -6,6 +6,8 @@ The integration test is written in python, using the `pytest` module.
 
 The test identity must be registered at the ubirch console / thing API in advance.
 
+`config.json`:
+
 ```json
 {
   "host": "<base URL of the UPP-signer instance under test>",

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -1,0 +1,28 @@
+# Integration test (python)
+
+The integration test is written in python, using the `pytest` module.
+
+## Configuration
+
+The test identity must be registered at the ubirch console / thing API in advance.
+
+```json
+{
+  "host": "<base URL of the UPP-signer instance under test>",
+  "staticAuth": "<static auth token>",
+  "testDevice": {
+    "uuid": "<test identity UUID>",
+    "password": "<test identity password>"
+  },
+  "env": "<ubirch backend environment>"
+}
+```
+
+## Run integration test
+
+```commandline
+python3 -m venv venv
+. venv/bin/activate
+pip install -r requirements.txt 
+pytest -v
+```

--- a/integration-test/helpers.py
+++ b/integration-test/helpers.py
@@ -1,0 +1,50 @@
+import hashlib
+import json
+import random
+import time
+import uuid
+from binascii import b2a_base64
+
+symbols = ("a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F",
+           "ä", "ë", "ï", "ö", "ü", "ÿ", "Ä", "Ë", "Ï", "Ö", "Ü", "Ÿ",
+           "`", "1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "-", "=",
+           "[", "]", ";", "'", "#", ",", ".", "/", "\\",
+           "¬", "!", '''"''', "£", "$", "%", "^", "*", "(", ")", "_", "+",
+           "{", "}", ":", "@", "~", "?", " |",
+           "&", "<", ">", "&#8482",
+           "®", "™", "U+2122", "%20", "\\n", "", "\
+")
+
+
+# generates a random JSON message
+def get_random_json() -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "ts": int(time.time()),
+        "big": random.getrandbits(53),
+        "tpl": (random.getrandbits(32), "".join(random.choices(symbols, k=4)),
+                random.getrandbits(8), "".join(random.choices(symbols, k=8)),
+                random.getrandbits(16), "".join(random.choices(symbols, k=2)),
+                random.getrandbits(4), "".join(random.choices(symbols, k=16))
+                ),
+        "lst": random.choices(symbols, k=8),
+        "map": {
+            random.choice(symbols): random.getrandbits(4),
+            random.choice(symbols): random.getrandbits(16),
+            random.choice(symbols): random.getrandbits(8),
+            random.choice(symbols): random.getrandbits(32)
+        },
+        "str": "".join(random.choices(symbols, k=128))
+    }
+
+
+def serialize(msg: dict) -> bytes:
+    return json.dumps(msg, separators=(',', ':'), sort_keys=True, ensure_ascii=False).encode()
+
+
+def hash_bytes(serialized: bytes) -> bytes:
+    return hashlib.sha256(serialized).digest()
+
+
+def to_base64(hash_bytes: bytes) -> str:
+    return b2a_base64(hash_bytes, newline=False).decode()

--- a/integration-test/helpers.py
+++ b/integration-test/helpers.py
@@ -3,7 +3,9 @@ import json
 import random
 import time
 import uuid
-from binascii import b2a_base64
+from binascii import b2a_base64, a2b_base64
+
+import ecdsa
 
 symbols = ("a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F",
            "ä", "ë", "ï", "ö", "ü", "ÿ", "Ä", "Ë", "Ï", "Ö", "Ü", "Ÿ",
@@ -48,3 +50,15 @@ def hash_bytes(serialized: bytes) -> bytes:
 
 def to_base64(hash_bytes: bytes) -> str:
     return b2a_base64(hash_bytes, newline=False).decode()
+
+
+def verify_upp_signature(upp_bytes: bytes, pubkey_bas64: bytes) -> bool:
+    pubkey_bytes = a2b_base64(pubkey_bas64)
+
+    vk = ecdsa.VerifyingKey.from_string(pubkey_bytes, curve=ecdsa.NIST256p, hashfunc=hashlib.sha256)
+
+    try:
+        vk.verify(upp_bytes[-64:], upp_bytes[:-66])
+        return True
+    except ecdsa.BadSignatureError:
+        return False

--- a/integration-test/helpers.py
+++ b/integration-test/helpers.py
@@ -44,7 +44,7 @@ def serialize(msg: dict) -> bytes:
     return json.dumps(msg, separators=(',', ':'), sort_keys=True, ensure_ascii=False).encode()
 
 
-def hash_bytes(serialized: bytes) -> bytes:
+def get_hash(serialized: bytes) -> bytes:
     return hashlib.sha256(serialized).digest()
 
 

--- a/integration-test/requirements.txt
+++ b/integration-test/requirements.txt
@@ -1,0 +1,3 @@
+msgpack
+pytest
+requests

--- a/integration-test/requirements.txt
+++ b/integration-test/requirements.txt
@@ -1,3 +1,4 @@
+ecdsa
 msgpack
 pytest
 requests

--- a/integration-test/test_integration.py
+++ b/integration-test/test_integration.py
@@ -1,7 +1,9 @@
 import binascii
 import json
 import random
+import uuid
 
+import msgpack
 import pytest
 import requests
 
@@ -116,11 +118,17 @@ class TestIntegration:
         res = requests.post(url, json=data_json, headers=header)
 
         assert res.status_code == 200
-        upp = binascii.a2b_base64(res.json()["upp"])
-        assert upp[0] == 0x96 and upp[1] == 0x23
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 6
+        assert unpacked[0] == 0x23
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[3] == 0x00
+        assert unpacked[4] == binascii.a2b_base64(data_hash_64)
 
         # check if hash is known by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -138,11 +146,17 @@ class TestIntegration:
         res = requests.post(url, data=data_hash_64, headers=header)
 
         assert res.status_code == 200
-        upp = binascii.a2b_base64(res.json()["upp"])
-        assert upp[0] == 0x96 and upp[1] == 0x23
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 6
+        assert unpacked[0] == 0x23
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[3] == 0x00
+        assert unpacked[4] == binascii.a2b_base64(data_hash_64)
 
         # check if hash is known by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -161,12 +175,18 @@ class TestIntegration:
         res = requests.post(url, json=data_json, headers=header)
 
         assert res.status_code == 200
-        upp = binascii.a2b_base64(res.json()["upp"])
-        assert upp[0] == 0x96 and upp[1] == 0x23
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):
             res.json()["response"]
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 6
+        assert unpacked[0] == 0x23
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[3] == 0x00
+        assert unpacked[4] == binascii.a2b_base64(data_hash_64)
 
         # make sure hash is unknown by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -183,12 +203,18 @@ class TestIntegration:
         res = requests.post(url, data=data_hash_64, headers=header)
 
         assert res.status_code == 200
-        upp = binascii.a2b_base64(res.json()["upp"])
-        assert upp[0] == 0x96 and upp[1] == 0x23
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):
             res.json()["response"]
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 6
+        assert unpacked[0] == 0x23
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[3] == 0x00
+        assert unpacked[4] == binascii.a2b_base64(data_hash_64)
 
         # make sure hash is unknown by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -206,11 +232,17 @@ class TestIntegration:
         res = requests.post(url, json=data_json, headers=header)
 
         assert res.status_code == 200
-        upp = binascii.a2b_base64(res.json()["upp"])
-        assert upp[0] == 0x95 and upp[1] == 0x22
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0x00
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
         # check if hash is known by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -226,17 +258,182 @@ class TestIntegration:
         res = requests.post(url, data=data_hash_64, headers=header)
 
         assert res.status_code == 200
-        upp = binascii.a2b_base64(res.json()["upp"])
-        assert upp[0] == 0x95 and upp[1] == 0x22
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0x00
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
         # check if hash is known by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
 
         assert verify_res.status_code == 200
         assert verify_res.json()["upp"] == res.json()["upp"]
+
+    def test_disable(self):
+        url = self.host + f"/{self.uuid}/disable"
+        header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
+        data_json = self.test_json
+        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+
+        res = requests.post(url, json=data_json, headers=header)
+
+        assert res.status_code == 200
+        assert res.json()["hash"] == data_hash_64
+        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0xFA
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
+        # assert hash has been disabled in ubirch backend
+        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+        #
+        # assert verify_res.status_code == 404
+
+    def test_disable_hash(self):
+        url = self.host + f"/{self.uuid}/disable/hash"
+        header = {'Content-Type': 'text/plain', 'X-Auth-Token': self.pwd}
+        data_hash_64 = self.test_hash
+
+        res = requests.post(url, data=data_hash_64, headers=header)
+
+        assert res.status_code == 200
+        assert res.json()["hash"] == data_hash_64
+        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0xFA
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
+        # assert hash has been disabled in ubirch backend
+        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+        #
+        # assert verify_res.status_code == 404
+
+    def test_enable(self):
+        url = self.host + f"/{self.uuid}/enable"
+        header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
+        data_json = self.test_json
+        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+
+        res = requests.post(url, json=data_json, headers=header)
+
+        assert res.status_code == 200
+        assert res.json()["hash"] == data_hash_64
+        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0xFB
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
+        # assert hash has been enabled in ubirch backend
+        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+        #
+        # assert verify_res.status_code == 200
+
+    def test_enable_hash(self):
+        url = self.host + f"/{self.uuid}/enable/hash"
+        header = {'Content-Type': 'text/plain', 'X-Auth-Token': self.pwd}
+        data_hash_64 = self.test_hash
+
+        res = requests.post(url, data=data_hash_64, headers=header)
+
+        assert res.status_code == 200
+        assert res.json()["hash"] == data_hash_64
+        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0xFB
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
+        # assert hash has been enabled in ubirch backend
+        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+        #
+        # assert verify_res.status_code == 200
+
+    def test_delete(self):
+        url = self.host + f"/{self.uuid}/delete"
+        header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
+        data_json = self.test_json
+        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+
+        res = requests.post(url, json=data_json, headers=header)
+
+        assert res.status_code == 200
+        assert res.json()["hash"] == data_hash_64
+        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0xFC
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
+        # assert hash has been deleted in ubirch backend
+        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+        #
+        # assert verify_res.status_code == 404
+
+    def test_delete_hash(self):
+        url = self.host + f"/{self.uuid}/delete/hash"
+        header = {'Content-Type': 'text/plain', 'X-Auth-Token': self.pwd}
+        data_hash_64 = self.test_hash
+
+        res = requests.post(url, data=data_hash_64, headers=header)
+
+        assert res.status_code == 200
+        assert res.json()["hash"] == data_hash_64
+        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["response"]["statusCode"] == 200
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0xFC
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
+        # assert hash has been deleted in ubirch backend
+        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+        #
+        # assert verify_res.status_code == 404
 
     def test_anchor_offline(self):
         url = self.host + f"/{self.uuid}/anchor/offline"
@@ -247,12 +444,18 @@ class TestIntegration:
         res = requests.post(url, json=data_json, headers=header)
 
         assert res.status_code == 200
-        upp = binascii.a2b_base64(res.json()["upp"])
-        assert upp[0] == 0x95 and upp[1] == 0x22
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):
             res.json()["response"]
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0x00
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
         # make sure hash is unknown by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -267,12 +470,18 @@ class TestIntegration:
         res = requests.post(url, data=data_hash_64, headers=header)
 
         assert res.status_code == 200
-        upp = binascii.a2b_base64(res.json()["upp"])
-        assert upp[0] == 0x95 and upp[1] == 0x22
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):
             res.json()["response"]
+
+        upp = binascii.a2b_base64(res.json()["upp"])
+        unpacked = msgpack.unpackb(upp)
+        assert len(unpacked) == 5
+        assert unpacked[0] == 0x22
+        assert unpacked[1] == uuid.UUID(self.uuid).bytes
+        assert unpacked[2] == 0x00
+        assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
         # make sure hash is unknown by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})

--- a/integration-test/test_integration.py
+++ b/integration-test/test_integration.py
@@ -1,0 +1,106 @@
+import json
+
+import requests
+
+
+class TestIntegration:
+    with open("config.json", "r") as f:
+        config = json.load(f)
+
+    def test_health(self):
+        url = self.config["baseURL"] + "/healthz"
+
+        res = requests.get(url)
+
+        assert res.status_code == 200
+        assert res.content == b'OK\n'
+
+    def test_ready(self):
+        url = self.config["baseURL"] + "/readyz"
+
+        res = requests.get(url)
+
+        assert res.status_code == 200
+        assert res.content == b'OK\n'
+
+    def test_metrics(self):
+        url = self.config["baseURL"] + "/metrics"
+
+        res = requests.get(url)
+
+        assert res.status_code == 200
+        assert res.content.__contains__(b'# TYPE http_requests_total counter') \
+               and res.content.__contains__(b'# TYPE http_response_time_seconds histogram') \
+               and res.content.__contains__(b'# TYPE response_status counter')
+
+    def test_register(self):
+        url = self.config["baseURL"] + "/register"
+        header = {'Content-Type': 'application/json', 'X-Auth-Token': self.config["staticAuth"]}
+
+        res = requests.put(url, json=self.config["testDevice"], headers=header)
+
+        assert (res.status_code == 200
+                and res.content.startswith(b'-----BEGIN CERTIFICATE REQUEST-----\n')
+                and res.content.endswith(b'-----END CERTIFICATE REQUEST-----\n')) \
+               or (res.status_code == 409
+                   and res.content == b'identity already registered\n')
+
+        # check if key was registered at ubirch identity service
+        uid = self.config["testDevice"]["uuid"]
+        env = self.config["env"]
+        identity_service_url = f"https://identity.{env}.ubirch.com/api/keyService/v1/pubkey/current/hardwareId/{uid}"
+
+        res = requests.get(identity_service_url)
+
+        assert len(res.json()) == 1
+
+    def test_csr(self):
+        uid = self.config["testDevice"]["uuid"]
+        url = self.config["baseURL"] + f"/{uid}/csr"
+        header = {'X-Auth-Token': self.config["staticAuth"]}
+
+        res = requests.get(url, headers=header)
+
+        assert res.status_code == 200
+        assert res.content.startswith(b'-----BEGIN CERTIFICATE REQUEST-----\n') \
+               and res.content.endswith(b'-----END CERTIFICATE REQUEST-----\n')
+
+    def test_deactivate(self):
+        uid = self.config["testDevice"]["uuid"]
+        url = self.config["baseURL"] + "/device/updateActive"
+        header = {'Content-Type': 'application/json', 'X-Auth-Token': self.config["staticAuth"]}
+        body = {"id": uid, "active": False}
+
+        res = requests.put(url, json=body, headers=header)
+
+        assert res.status_code == 200
+        assert res.content == b'key deactivation successful\n'
+
+        # check if key was deleted at ubirch identity service
+        uid = self.config["testDevice"]["uuid"]
+        env = self.config["env"]
+        identity_service_url = f"https://identity.{env}.ubirch.com/api/keyService/v1/pubkey/current/hardwareId/{uid}"
+
+        res = requests.get(identity_service_url)
+
+        assert len(res.json()) == 0
+
+    def test_reactivate(self):
+        uid = self.config["testDevice"]["uuid"]
+        url = self.config["baseURL"] + "/device/updateActive"
+        header = {'Content-Type': 'application/json', 'X-Auth-Token': self.config["staticAuth"]}
+        body = {"id": uid, "active": True}
+
+        res = requests.put(url, json=body, headers=header)
+
+        assert res.status_code == 200
+        assert res.content == b'key reactivation successful\n'
+
+        # check if key was registered at ubirch identity service
+        uid = self.config["testDevice"]["uuid"]
+        env = self.config["env"]
+        identity_service_url = f"https://identity.{env}.ubirch.com/api/keyService/v1/pubkey/current/hardwareId/{uid}"
+
+        res = requests.get(identity_service_url)
+
+        assert len(res.json()) == 1

--- a/integration-test/test_integration.py
+++ b/integration-test/test_integration.py
@@ -337,11 +337,10 @@ class TestIntegration:
         assert unpacked[2] == 0xFA
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
-        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
         # assert hash has been disabled in ubirch backend
-        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
-        #
-        # assert verify_res.status_code == 404
+        verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+
+        assert verify_res.status_code == 404
 
     def test_disable_hash(self):
         url = self.host + f"/{self.uuid}/disable/hash"
@@ -363,11 +362,10 @@ class TestIntegration:
         assert unpacked[2] == 0xFA
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
-        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
         # assert hash has been disabled in ubirch backend
-        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
-        #
-        # assert verify_res.status_code == 404
+        verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+
+        assert verify_res.status_code == 404
 
     def test_enable(self):
         url = self.host + f"/{self.uuid}/enable"
@@ -390,11 +388,10 @@ class TestIntegration:
         assert unpacked[2] == 0xFB
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
-        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
         # assert hash has been enabled in ubirch backend
-        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
-        #
-        # assert verify_res.status_code == 200
+        verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+
+        assert verify_res.status_code == 200
 
     def test_enable_hash(self):
         url = self.host + f"/{self.uuid}/enable/hash"
@@ -416,11 +413,10 @@ class TestIntegration:
         assert unpacked[2] == 0xFB
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
-        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
         # assert hash has been enabled in ubirch backend
-        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
-        #
-        # assert verify_res.status_code == 200
+        verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+
+        assert verify_res.status_code == 200
 
     def test_delete(self):
         url = self.host + f"/{self.uuid}/delete"
@@ -443,11 +439,10 @@ class TestIntegration:
         assert unpacked[2] == 0xFC
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
-        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
         # assert hash has been deleted in ubirch backend
-        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
-        #
-        # assert verify_res.status_code == 404
+        verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+
+        assert verify_res.status_code == 404
 
     def test_delete_hash(self):
         url = self.host + f"/{self.uuid}/delete/hash"
@@ -469,11 +464,10 @@ class TestIntegration:
         assert unpacked[2] == 0xFC
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
 
-        # FIXME race-condition or cached hash by verification service makes the following assertion fail sometimes
         # assert hash has been deleted in ubirch backend
-        # verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
-        #
-        # assert verify_res.status_code == 404
+        verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+
+        assert verify_res.status_code == 404
 
     def test_anchor_offline(self):
         url = self.host + f"/{self.uuid}/anchor/offline"

--- a/integration-test/test_integration.py
+++ b/integration-test/test_integration.py
@@ -237,3 +237,44 @@ class TestIntegration:
 
         assert verify_res.status_code == 200
         assert verify_res.json()["upp"] == res.json()["upp"]
+
+    def test_anchor_offline(self):
+        url = self.host + f"/{self.uuid}/anchor/offline"
+        header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
+        data_json = get_random_json()
+        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+
+        res = requests.post(url, json=data_json, headers=header)
+
+        assert res.status_code == 200
+        upp = binascii.a2b_base64(res.json()["upp"])
+        assert upp[0] == 0x95 and upp[1] == 0x22
+        assert res.json()["hash"] == data_hash_64
+        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        with pytest.raises(KeyError):
+            res.json()["response"]
+
+        # make sure hash is unknown by ubirch verification service
+        verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+
+        assert verify_res.status_code == 404
+
+    def test_anchor_offline_hash(self):
+        url = self.host + f"/{self.uuid}/anchor/offline/hash"
+        header = {'Content-Type': 'text/plain', 'X-Auth-Token': self.pwd}
+        data_hash_64 = to_base64(random.randbytes(32))
+
+        res = requests.post(url, data=data_hash_64, headers=header)
+
+        assert res.status_code == 200
+        upp = binascii.a2b_base64(res.json()["upp"])
+        assert upp[0] == 0x95 and upp[1] == 0x22
+        assert res.json()["hash"] == data_hash_64
+        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        with pytest.raises(KeyError):
+            res.json()["response"]
+
+        # make sure hash is unknown by ubirch verification service
+        verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
+
+        assert verify_res.status_code == 404

--- a/integration-test/test_integration.py
+++ b/integration-test/test_integration.py
@@ -136,7 +136,17 @@ class TestIntegration:
         assert verify_res.status_code == 200
         assert verify_res.json()["upp"] == res.json()["upp"]
 
-        # todo check if consecutive requests to this endpoint result in correctly chained UPPs
+        # check if consecutive requests to this endpoint result in correctly chained UPPs
+        prev_signature = unpacked[5]
+        for i in range(10):
+            res = requests.post(url, json=get_random_json(), headers=header)
+
+            assert res.status_code == 200
+
+            unpacked = msgpack.unpackb(binascii.a2b_base64(res.json()["upp"]))
+            assert unpacked[2] == prev_signature, f"chain check failed in loop {i}"
+
+            prev_signature = unpacked[5]
 
     def test_chain_hash(self):
         url = self.host + f"/{self.uuid}/hash"
@@ -164,7 +174,17 @@ class TestIntegration:
         assert verify_res.status_code == 200
         assert verify_res.json()["upp"] == res.json()["upp"]
 
-        # todo check if consecutive requests to this endpoint result in correctly chained UPPs
+        # check if consecutive requests to this endpoint result in correctly chained UPPs
+        prev_signature = unpacked[5]
+        for i in range(10):
+            res = requests.post(url, data=to_base64(random.randbytes(32)), headers=header)
+
+            assert res.status_code == 200
+
+            unpacked = msgpack.unpackb(binascii.a2b_base64(res.json()["upp"]))
+            assert unpacked[2] == prev_signature, f"chain check failed in loop {i}"
+
+            prev_signature = unpacked[5]
 
     def test_chain_offline(self):
         url = self.host + f"/{self.uuid}/offline"
@@ -193,7 +213,17 @@ class TestIntegration:
 
         assert verify_res.status_code == 404
 
-        # todo check if consecutive requests to this endpoint result in correctly chained UPPs
+        # check if consecutive requests to this endpoint result in correctly chained UPPs
+        prev_signature = unpacked[5]
+        for i in range(10):
+            res = requests.post(url, json=get_random_json(), headers=header)
+
+            assert res.status_code == 200
+
+            unpacked = msgpack.unpackb(binascii.a2b_base64(res.json()["upp"]))
+            assert unpacked[2] == prev_signature, f"chain check failed in loop {i}"
+
+            prev_signature = unpacked[5]
 
     def test_chain_offline_hash(self):
         url = self.host + f"/{self.uuid}/offline/hash"
@@ -221,7 +251,17 @@ class TestIntegration:
 
         assert verify_res.status_code == 404
 
-        # todo check if consecutive requests to this endpoint result in correctly chained UPPs
+        # check if consecutive requests to this endpoint result in correctly chained UPPs
+        prev_signature = unpacked[5]
+        for i in range(10):
+            res = requests.post(url, data=to_base64(random.randbytes(32)), headers=header)
+
+            assert res.status_code == 200
+
+            unpacked = msgpack.unpackb(binascii.a2b_base64(res.json()["upp"]))
+            assert unpacked[2] == prev_signature, f"chain check failed in loop {i}"
+
+            prev_signature = unpacked[5]
 
     def test_anchor(self):
         url = self.host + f"/{self.uuid}/anchor"
@@ -518,6 +558,9 @@ class TestIntegration:
         signing_res = requests.post(url, data=data_hash_64, headers=header)
 
         assert signing_res.status_code == 200
+
+        # fixme we might need to wait here or make sure to use quick verification endpoint
+        #  -> header parameter for quick verification?
 
         # verify hash
         url = self.host + "/verify/hash"

--- a/integration-test/test_integration.py
+++ b/integration-test/test_integration.py
@@ -8,7 +8,7 @@ import msgpack
 import pytest
 import requests
 
-from helpers import get_random_json, serialize, hash_bytes, to_base64
+from helpers import get_random_json, serialize, hash_bytes, to_base64, verify_upp_signature
 
 
 class TestIntegration:
@@ -120,7 +120,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -130,6 +129,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[3] == 0x00
         assert unpacked[4] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # check if hash is known by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -158,7 +163,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -168,6 +172,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[3] == 0x00
         assert unpacked[4] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # check if hash is known by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -197,7 +207,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):
             res.json()["response"]
 
@@ -208,6 +217,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[3] == 0x00
         assert unpacked[4] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # make sure hash is unknown by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -235,7 +250,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):
             res.json()["response"]
 
@@ -246,6 +260,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[3] == 0x00
         assert unpacked[4] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # make sure hash is unknown by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -274,7 +294,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -284,6 +303,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0x00
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # check if hash is known by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -300,7 +325,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -310,6 +334,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0x00
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # check if hash is known by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -327,7 +357,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -337,6 +366,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0xFA
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # assert hash has been disabled in ubirch backend
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -352,7 +387,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -362,6 +396,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0xFA
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # assert hash has been disabled in ubirch backend
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -378,7 +418,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -388,6 +427,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0xFB
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # assert hash has been enabled in ubirch backend
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -403,7 +448,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -413,6 +457,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0xFB
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # assert hash has been enabled in ubirch backend
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -429,7 +479,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -439,6 +488,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0xFC
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # assert hash has been deleted in ubirch backend
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -454,7 +509,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
 
         upp = binascii.a2b_base64(res.json()["upp"])
@@ -464,6 +518,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0xFC
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # assert hash has been deleted in ubirch backend
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -480,7 +540,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):
             res.json()["response"]
 
@@ -491,6 +550,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0x00
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # make sure hash is unknown by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})
@@ -506,7 +571,6 @@ class TestIntegration:
 
         assert res.status_code == 200
         assert res.json()["hash"] == data_hash_64
-        assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):
             res.json()["response"]
 
@@ -517,6 +581,12 @@ class TestIntegration:
         assert unpacked[1] == uuid.UUID(self.uuid).bytes
         assert unpacked[2] == 0x00
         assert unpacked[3] == binascii.a2b_base64(data_hash_64)
+
+        registered_pubkey = requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
+        assert res.json()["publicKey"] == registered_pubkey
+
+        # verify UPP signature locally
+        assert verify_upp_signature(upp, registered_pubkey), "invalid UPP signature"
 
         # make sure hash is unknown by ubirch verification service
         verify_res = requests.post(self.verify_url, data=data_hash_64, headers={'Content-Type': 'text/plain'})

--- a/integration-test/test_integration.py
+++ b/integration-test/test_integration.py
@@ -112,6 +112,8 @@ class TestIntegration:
         res = requests.post(url, json=data_json, headers=header)
 
         assert res.status_code == 200
+        upp = binascii.a2b_base64(res.json()["upp"])
+        assert upp[0] == 0x96 and upp[1] == 0x23
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
@@ -132,6 +134,8 @@ class TestIntegration:
         res = requests.post(url, data=data_hash_64, headers=header)
 
         assert res.status_code == 200
+        upp = binascii.a2b_base64(res.json()["upp"])
+        assert upp[0] == 0x96 and upp[1] == 0x23
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         assert res.json()["response"]["statusCode"] == 200
@@ -153,6 +157,8 @@ class TestIntegration:
         res = requests.post(url, json=data_json, headers=header)
 
         assert res.status_code == 200
+        upp = binascii.a2b_base64(res.json()["upp"])
+        assert upp[0] == 0x96 and upp[1] == 0x23
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):
@@ -173,6 +179,8 @@ class TestIntegration:
         res = requests.post(url, data=data_hash_64, headers=header)
 
         assert res.status_code == 200
+        upp = binascii.a2b_base64(res.json()["upp"])
+        assert upp[0] == 0x96 and upp[1] == 0x23
         assert res.json()["hash"] == data_hash_64
         assert res.json()["publicKey"] == requests.get(self.pubkey_url).json()[0]["pubKeyInfo"]["pubKey"]
         with pytest.raises(KeyError):

--- a/integration-test/test_integration.py
+++ b/integration-test/test_integration.py
@@ -1,6 +1,7 @@
 import binascii
 import json
 import random
+import time
 import uuid
 
 import msgpack
@@ -533,6 +534,10 @@ class TestIntegration:
 
         assert signing_res.status_code == 200
 
+        # since the UPP-signer does not use the quick verify endpoint, we need
+        # to sleep after anchoring to ensure the hash can be verified
+        time.sleep(1)
+
         # verify data
         url = self.host + "/verify"
         verify_res = requests.post(url, json=data_json, headers={'Content-Type': 'application/json'})
@@ -553,8 +558,9 @@ class TestIntegration:
 
         assert signing_res.status_code == 200
 
-        # fixme we might need to wait here or make sure to use quick verification endpoint
-        #  -> header parameter for quick verification?
+        # since the UPP-signer does not use the quick verify endpoint, we need
+        # to sleep after anchoring to ensure the hash can be verified
+        time.sleep(1)
 
         # verify hash
         url = self.host + "/verify/hash"

--- a/integration-test/test_integration.py
+++ b/integration-test/test_integration.py
@@ -8,7 +8,7 @@ import msgpack
 import pytest
 import requests
 
-from helpers import get_random_json, serialize, hash_bytes, to_base64, verify_upp_signature
+from helpers import get_random_json, serialize, get_hash, to_base64, verify_upp_signature
 
 
 class TestIntegration:
@@ -114,7 +114,7 @@ class TestIntegration:
         url = self.host + f"/{self.uuid}"
         header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
         data_json = get_random_json()
-        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+        data_hash_64 = to_base64(get_hash(serialize(data_json)))
 
         res = requests.post(url, json=data_json, headers=header)
 
@@ -201,7 +201,7 @@ class TestIntegration:
         url = self.host + f"/{self.uuid}/offline"
         header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
         data_json = get_random_json()
-        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+        data_hash_64 = to_base64(get_hash(serialize(data_json)))
 
         res = requests.post(url, json=data_json, headers=header)
 
@@ -288,7 +288,7 @@ class TestIntegration:
         url = self.host + f"/{self.uuid}/anchor"
         header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
         data_json = self.test_json
-        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+        data_hash_64 = to_base64(get_hash(serialize(data_json)))
 
         res = requests.post(url, json=data_json, headers=header)
 
@@ -351,7 +351,7 @@ class TestIntegration:
         url = self.host + f"/{self.uuid}/disable"
         header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
         data_json = self.test_json
-        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+        data_hash_64 = to_base64(get_hash(serialize(data_json)))
 
         res = requests.post(url, json=data_json, headers=header)
 
@@ -412,7 +412,7 @@ class TestIntegration:
         url = self.host + f"/{self.uuid}/enable"
         header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
         data_json = self.test_json
-        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+        data_hash_64 = to_base64(get_hash(serialize(data_json)))
 
         res = requests.post(url, json=data_json, headers=header)
 
@@ -473,7 +473,7 @@ class TestIntegration:
         url = self.host + f"/{self.uuid}/delete"
         header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
         data_json = self.test_json
-        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+        data_hash_64 = to_base64(get_hash(serialize(data_json)))
 
         res = requests.post(url, json=data_json, headers=header)
 
@@ -534,7 +534,7 @@ class TestIntegration:
         url = self.host + f"/{self.uuid}/anchor/offline"
         header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
         data_json = get_random_json()
-        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+        data_hash_64 = to_base64(get_hash(serialize(data_json)))
 
         res = requests.post(url, json=data_json, headers=header)
 
@@ -598,7 +598,7 @@ class TestIntegration:
         url = self.host + f"/{self.uuid}"
         header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
         data_json = get_random_json()
-        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+        data_hash_64 = to_base64(get_hash(serialize(data_json)))
 
         signing_res = requests.post(url, json=data_json, headers=header)
 
@@ -647,7 +647,7 @@ class TestIntegration:
         url = self.host + f"/{self.uuid}/offline"
         header = {'Content-Type': 'application/json', 'X-Auth-Token': self.pwd}
         data_json = get_random_json()
-        data_hash_64 = to_base64(hash_bytes(serialize(data_json)))
+        data_hash_64 = to_base64(get_hash(serialize(data_json)))
 
         signing_res = requests.post(url, json=data_json, headers=header)
 

--- a/load-test/sender.go
+++ b/load-test/sender.go
@@ -51,16 +51,10 @@ func NewSender() *Sender {
 func (s *Sender) register(url urlpkg.URL, id, auth, registerAuth string) error {
 	url.Path = path.Join(url.Path, "register")
 
-	header := http.Header{}
-	header.Set("Content-Type", "application/json")
-	header.Set("X-Auth-Token", registerAuth)
-
-	registrationData := map[string]string{
+	body, err := json.Marshal(map[string]string{
 		"uuid":     id,
 		"password": auth,
-	}
-
-	body, err := json.Marshal(registrationData)
+	})
 	if err != nil {
 		return err
 	}
@@ -70,7 +64,8 @@ func (s *Sender) register(url urlpkg.URL, id, auth, registerAuth string) error {
 		return err
 	}
 
-	req.Header = header
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Auth-Token", registerAuth)
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {

--- a/main/adapters/handlers/signer_test.go
+++ b/main/adapters/handlers/signer_test.go
@@ -102,7 +102,7 @@ func TestSigner_Sign(t *testing.T) {
 			},
 			tcChecks: func(t *testing.T, resp h.HTTPResponse, m *mock.Mock) {
 				m.AssertExpectations(t)
-				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testChainedUPP, testPublicKey, testBckndResp, testRequestID), resp)
+				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testChainedUPP, testPublicKey, &testBckndResp, testRequestID), resp)
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestSigner_Sign(t *testing.T) {
 			},
 			tcChecks: func(t *testing.T, resp h.HTTPResponse, m *mock.Mock) {
 				m.AssertExpectations(t)
-				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testChainedUPP, testPublicKey, h.HTTPResponse{}, ""), resp)
+				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testChainedUPP, testPublicKey, nil, ""), resp)
 			},
 		},
 		{
@@ -158,7 +158,7 @@ func TestSigner_Sign(t *testing.T) {
 			},
 			tcChecks: func(t *testing.T, resp h.HTTPResponse, m *mock.Mock) {
 				m.AssertExpectations(t)
-				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, testBckndResp, testRequestID), resp)
+				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, &testBckndResp, testRequestID), resp)
 			},
 		},
 		{
@@ -183,7 +183,7 @@ func TestSigner_Sign(t *testing.T) {
 			},
 			tcChecks: func(t *testing.T, resp h.HTTPResponse, m *mock.Mock) {
 				m.AssertExpectations(t)
-				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, h.HTTPResponse{}, ""), resp)
+				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, nil, ""), resp)
 			},
 		},
 		{
@@ -208,7 +208,7 @@ func TestSigner_Sign(t *testing.T) {
 			},
 			tcChecks: func(t *testing.T, resp h.HTTPResponse, m *mock.Mock) {
 				m.AssertExpectations(t)
-				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, testBckndResp, testRequestID), resp)
+				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, &testBckndResp, testRequestID), resp)
 			},
 		},
 		{
@@ -233,7 +233,7 @@ func TestSigner_Sign(t *testing.T) {
 			},
 			tcChecks: func(t *testing.T, resp h.HTTPResponse, m *mock.Mock) {
 				m.AssertExpectations(t)
-				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, testBckndResp, testRequestID), resp)
+				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, &testBckndResp, testRequestID), resp)
 			},
 		},
 		{
@@ -258,7 +258,7 @@ func TestSigner_Sign(t *testing.T) {
 			},
 			tcChecks: func(t *testing.T, resp h.HTTPResponse, m *mock.Mock) {
 				m.AssertExpectations(t)
-				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, testBckndResp, testRequestID), resp)
+				assert.Equal(t, getSigningResponse(http.StatusOK, testHash[:], testSignedUPP, testPublicKey, &testBckndResp, testRequestID), resp)
 			},
 		},
 	}

--- a/main/adapters/http_server/common.go
+++ b/main/adapters/http_server/common.go
@@ -34,7 +34,7 @@ const (
 	JSONType = "application/json"
 
 	XUPPHeader  = "X-Ubirch-UPP"
-	XAuthHeader = "x-auth-token"
+	XAuthHeader = "X-Auth-Token"
 
 	HexEncoding = "hex"
 


### PR DESCRIPTION
**Added:**
- python integration tests using `pytest`

**Changed:**
- offline signing response body used to contain `response` field with nil values, i.e. ```'response': {'statusCode': 0, 'header': None, 'content': None}```.  Now the `response` field is omitted in offline signing responses.