### PR TITLE
CPI-1387 automatic test execution

### DIFF
--- a/main/adapters/repository/database_sqlite_test.go
+++ b/main/adapters/repository/database_sqlite_test.go
@@ -262,7 +262,7 @@ func TestDatabaseManager_StoreAuth_sqlite(t *testing.T) {
 	assert.Equal(t, base64.StdEncoding.EncodeToString(newAuth), auth)
 }
 
-func TestNewSqlDatabaseInfo_Ready_sqlite(t *testing.T) {
+func TestDatabaseManager_Ready_sqlite(t *testing.T) {
 	dm, err := initSQLiteDB(t, 0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -271,7 +271,7 @@ func TestNewSqlDatabaseInfo_Ready_sqlite(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNewSqlDatabaseInfo_NotReady_sqlite(t *testing.T) {
+func TestDatabaseManager_NotReady_sqlite(t *testing.T) {
 	dsn := filepath.Join(t.TempDir(), testSQLiteDSN)
 	dm, err := NewDatabaseManager(SQLite, dsn, 0)
 	require.NoError(t, err)
@@ -284,7 +284,7 @@ func TestNewSqlDatabaseInfo_NotReady_sqlite(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestStoreExisting_sqlite(t *testing.T) {
+func TestDatabaseManager_StoreExisting_sqlite(t *testing.T) {
 	dm, err := initSQLiteDB(t, 0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)

--- a/main/adapters/repository/database_test.go
+++ b/main/adapters/repository/database_test.go
@@ -25,6 +25,11 @@ import (
 const testLoad = 100
 
 func TestDatabaseManager(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -100,6 +105,11 @@ func TestDatabaseManager(t *testing.T) {
 }
 
 func TestDatabaseManager_StoreActiveFlag(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -140,6 +150,11 @@ func TestDatabaseManager_StoreActiveFlag(t *testing.T) {
 }
 
 func TestDatabaseManager_SetSignature(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -187,6 +202,11 @@ func TestDatabaseManager_SetSignature(t *testing.T) {
 }
 
 func TestDatabaseManager_LoadSignatureForUpdate(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -227,6 +247,11 @@ func TestDatabaseManager_LoadSignatureForUpdate(t *testing.T) {
 }
 
 func TestDatabaseManager_StoreAuth(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -274,6 +299,11 @@ func TestDatabaseManager_StoreAuth(t *testing.T) {
 }
 
 func TestDatabaseManager_Ready(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -301,6 +331,11 @@ func TestDatabaseManager_NotReady(t *testing.T) {
 }
 
 func TestDatabaseManager_StoreExisting(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -331,6 +366,11 @@ func TestDatabaseManager_StoreExisting(t *testing.T) {
 }
 
 func TestDatabaseManager_CancelTransaction(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -367,6 +407,11 @@ func TestDatabaseManager_CancelTransaction(t *testing.T) {
 }
 
 func TestDatabaseManager_StartTransaction(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(1)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -384,6 +429,11 @@ func TestDatabaseManager_StartTransaction(t *testing.T) {
 }
 
 func TestDatabaseManager_InvalidTransactionCtx(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -414,6 +464,11 @@ func TestDatabaseManager_InvalidTransactionCtx(t *testing.T) {
 }
 
 func TestDatabaseLoad(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	wg := &sync.WaitGroup{}
 
 	dm, err := initDB(0)
@@ -461,6 +516,11 @@ func TestDatabaseLoad(t *testing.T) {
 }
 
 func TestDatabaseManager_RecoverUndefinedTable(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	c, err := getConfig()
 	require.NoError(t, err)
 
@@ -478,6 +538,11 @@ func TestDatabaseManager_RecoverUndefinedTable(t *testing.T) {
 }
 
 func TestDatabaseManager_Retry(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	c, err := getConfig()
 	require.NoError(t, err)
 
@@ -510,6 +575,11 @@ func TestDatabaseManager_Retry(t *testing.T) {
 }
 
 func TestDatabaseManager_StoreExternalIdentity(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -547,6 +617,11 @@ func TestDatabaseManager_StoreExternalIdentity(t *testing.T) {
 }
 
 func TestDatabaseManager_GetIdentityUUIDs(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -574,6 +649,11 @@ func TestDatabaseManager_GetIdentityUUIDs(t *testing.T) {
 }
 
 func TestDatabaseManager_GetExternalIdentityUUIDs(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)

--- a/main/adapters/repository/database_test.go
+++ b/main/adapters/repository/database_test.go
@@ -273,7 +273,7 @@ func TestDatabaseManager_StoreAuth(t *testing.T) {
 	assert.Equal(t, base64.StdEncoding.EncodeToString(newAuth), auth)
 }
 
-func TestNewSqlDatabaseInfo_Ready(t *testing.T) {
+func TestDatabaseManager_Ready(t *testing.T) {
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)
@@ -282,7 +282,7 @@ func TestNewSqlDatabaseInfo_Ready(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestNewSqlDatabaseInfo_NotReady(t *testing.T) {
+func TestDatabaseManager_NotReady(t *testing.T) {
 	// use DSN that is valid, but not reachable
 	unreachableDSN := "postgres://nousr:nopwd@localhost:0000/nodatabase"
 
@@ -300,7 +300,7 @@ func TestNewSqlDatabaseInfo_NotReady(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestStoreExisting(t *testing.T) {
+func TestDatabaseManager_StoreExisting(t *testing.T) {
 	dm, err := initDB(0)
 	require.NoError(t, err)
 	defer cleanUpDB(t, dm)

--- a/main/adapters/repository/migrator_test.go
+++ b/main/adapters/repository/migrator_test.go
@@ -22,11 +22,16 @@ const (
 func TestMigrate(t *testing.T) {
 	testCases := []struct {
 		name   string
-		setDSN func(*config.Config, string) error
+		setDSN func(*testing.T, *config.Config, string) error
 	}{
 		{
 			name: "postgres migration",
-			setDSN: func(c *config.Config, _ string) error {
+			setDSN: func(t *testing.T, c *config.Config, _ string) error {
+				// this test communicates with the actual postgres database
+				if testing.Short() {
+					t.Skipf("skipping integration test %s in short mode", t.Name())
+				}
+
 				dbConf, err := getConfig()
 				if err != nil {
 					return err
@@ -38,7 +43,7 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			name: "sqlite migration",
-			setDSN: func(c *config.Config, configDir string) error {
+			setDSN: func(t *testing.T, c *config.Config, configDir string) error {
 				c.DbDriver = SQLite
 				c.DbDSN = filepath.Join(configDir, testSQLiteDSN)
 				return nil
@@ -52,7 +57,7 @@ func TestMigrate(t *testing.T) {
 			conf := setupMigrationTest(t, tmp)
 			defer cleanUpMigrationTest(t, conf, tmp)
 
-			err := c.setDSN(conf, tmp)
+			err := c.setDSN(t, conf, tmp)
 			require.NoError(t, err)
 
 			err = Migrate(conf, tmp)

--- a/main/adapters/repository/protocol_test.go
+++ b/main/adapters/repository/protocol_test.go
@@ -554,6 +554,11 @@ func TestProtocol_Cache(t *testing.T) {
 }
 
 func TestProtocolLoad(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
 	wg := &sync.WaitGroup{}
 
 	dm, err := initDB(0)

--- a/main/main_test.go
+++ b/main/main_test.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 )
 
-//Flags used for skipping tests which need a reachable running client
+// Flags used for skipping tests which need a reachable running client
 var clientOnline = flag.Bool("clientOnline", false, "perform tests on a running client instance")
 
-//For these tests to work the client needs to be started and reachable at the following address
+// For these tests to work the client needs to be started and reachable at the following address
 const (
 	defaultClientAddress = "http://localhost:8080"
 )
@@ -31,7 +31,7 @@ const (
 var defaultUUID = ""
 var defaultAuthToken = ""
 
-//Helper function for constant test JSON definitions which panics if the test JSON can't be marshaled to bytes
+// Helper function for constant test JSON definitions which panics if the test JSON can't be marshaled to bytes
 func mustMarshalJSON(v interface{}) []byte {
 	jsonBytes, err := json.Marshal(v)
 	if err != nil {
@@ -68,32 +68,34 @@ func createHashRequest(address string, authToken string, uuidString string, hash
 // TestMain is the main test function, which checks the requirements and executes all other tests,
 // or exits with error message
 func TestMain(m *testing.M) {
-	const (
-		configFile = "test_config.json"
-	)
-	// load the configuration
-	conf := config.Config{}
-	err := conf.Load(".", configFile)
-	if err != nil {
-		log.Fatalf("\r\n" +
-			"###\r\n" +
-			"ERROR loading the configuration file: \r\n" + err.Error() + "'\r\n" +
-			"Please copy the 'sample_test_config.json' to '" + configFile + "'\r\n" +
-			"and enter the correct <UUID:AuthToken>, you want to test.\r\n\n" +
-			"The same configuration has to be used in the docker container,\r\n" +
-			"where it is named config.json\r\n" +
-			"###")
-	}
-	// extract the UUID and the Auth toke from the FIRST entry in the config
-	for key, value := range conf.Devices {
-		defaultUUID = key
-		defaultAuthToken = value
-		break
-	}
+	if *clientOnline {
+		const (
+			configFile = "test_config.json"
+		)
+		// load the configuration
+		conf := config.Config{}
+		err := conf.Load(".", configFile)
+		if err != nil {
+			log.Fatalf("\r\n" +
+				"###\r\n" +
+				"ERROR loading the configuration file: \r\n" + err.Error() + "'\r\n" +
+				"Please copy the 'sample_test_config.json' to '" + configFile + "'\r\n" +
+				"and enter the correct <UUID:AuthToken>, you want to test.\r\n\n" +
+				"The same configuration has to be used in the docker container,\r\n" +
+				"where it is named config.json\r\n" +
+				"###")
+		}
+		// extract the UUID and the Auth toke from the FIRST entry in the config
+		for key, value := range conf.Devices {
+			defaultUUID = key
+			defaultAuthToken = value
+			break
+		}
 
-	// run all other tests
-	code := m.Run()
-	os.Exit(code)
+		// run all other tests
+		code := m.Run()
+		os.Exit(code)
+	}
 }
 
 //################################################################
@@ -146,7 +148,7 @@ func TestHashRandom(t *testing.T) {
 	}
 }
 
-//TestHashTableFail tests cases with a specific hash as an input which must fail
+// TestHashTableFail tests cases with a specific hash as an input which must fail
 func TestHashTableFail(t *testing.T) {
 	if !*clientOnline {
 		t.Skip("skipping test in offline mode, use 'clientOnline' flag to enable")
@@ -222,7 +224,7 @@ func TestHashTableFail(t *testing.T) {
 	}
 }
 
-//TestHashTableSucceed tests cases with a specific hash as an input which must succeed
+// TestHashTableSucceed tests cases with a specific hash as an input which must succeed
 func TestHashTableSucceed(t *testing.T) {
 	if !*clientOnline {
 		t.Skip("skipping test in offline mode, use 'clientOnline' flag to enable")
@@ -284,7 +286,7 @@ func TestHashTableSucceed(t *testing.T) {
 	}
 }
 
-//TestJSONDataLength tests input of random Key/Value Pairs into the JSON endpoint
+// TestJSONDataLength tests input of random Key/Value Pairs into the JSON endpoint
 func TestJSONRandomKeyValuePairs(t *testing.T) {
 	if !*clientOnline {
 		t.Skip("skipping test in offline mode, use 'clientOnline' flag to enable")
@@ -364,7 +366,7 @@ func TestJSONRandomKeyValuePairs(t *testing.T) {
 	}
 }
 
-//TestJSONTableFail tests cases with a specific JSON as an input which must fail
+// TestJSONTableFail tests cases with a specific JSON as an input which must fail
 func TestJSONTableFail(t *testing.T) {
 	if !*clientOnline {
 		t.Skip("skipping test in offline mode, use 'clientOnline' flag to enable")
@@ -419,7 +421,7 @@ func TestJSONTableFail(t *testing.T) {
 	}
 }
 
-//TestJSONTableSucceed tests cases with a specific JSON as an input which must succeed
+// TestJSONTableSucceed tests cases with a specific JSON as an input which must succeed
 func TestJSONTableSucceed(t *testing.T) {
 	if !*clientOnline {
 		t.Skip("skipping test in offline mode, use 'clientOnline' flag to enable")
@@ -507,7 +509,7 @@ func TestJSONTableSucceed(t *testing.T) {
 	}
 }
 
-//TestJSONDataLength tests various length data input into the JSON endpoint
+// TestJSONDataLength tests various length data input into the JSON endpoint
 func TestJSONDataLength(t *testing.T) {
 	if !*clientOnline {
 		t.Skip("skipping test in offline mode, use 'clientOnline' flag to enable")


### PR DESCRIPTION
**Added:**

- to skip tests with dependencies to an actual database, run `go test` with flag `-short`