### PR TITLE
FIX(CPI-1415): DB migration script support 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
       - master # or the name of your main branch
-  pull_request:
-    types: [opened, synchronize, reopened]
-    
-    
+    #  pull_request:
+    #    types: [opened, synchronize, reopened]
+
+
 ###############
 # Set the Job #
 ###############

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ EXPOSE 8080/tcp
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder app/main/main ubirch-client
 ENTRYPOINT ["/ubirch-client"]
-CMD ["-configdirectory", "/data"]
+CMD ["-config-directory", "/data"]

--- a/README.md
+++ b/README.md
@@ -991,6 +991,8 @@ Lastly, the legacy context files can be deleted.
 rm -rf keys.json keys.json.bck signatures
 ```
 
+> The support for migration from file-based context into a database was dropped after version `v3.0.0`.
+
 ## Quick Start
 
 1. Configuration

--- a/main/adapters/database/database_sqlite_test.go
+++ b/main/adapters/database/database_sqlite_test.go
@@ -595,12 +595,44 @@ func TestDatabaseManager_GetExternalIdentityUUIDs_sqlite(t *testing.T) {
 	}
 }
 
+func TestDatabaseManager_NewDatabaseManager_DatabaseAlreadyOnLatestVersion_sqlite(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
+
+	// migrate database schema to the latest version
+	err := migrateUp(SQLite, dsn)
+	require.NoError(t, err)
+
+	dm, err := NewDatabaseManager(SQLite, dsn, 0)
+	assert.NoError(t, err)
+
+	cleanUpDB(t, &extendedDatabaseManager{
+		DatabaseManager: dm,
+		dsn:             dsn,
+	})
+}
+
+func TestDatabaseManager_NewDatabaseManager_DatabaseAlreadyExists_sqlite(t *testing.T) {
+	dsn := filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
+
+	// migrate database schema to the latest version
+	err := migrateTo(SQLite, dsn, 1)
+	require.NoError(t, err)
+
+	dm, err := NewDatabaseManager(SQLite, dsn, 0)
+	assert.NoError(t, err)
+
+	cleanUpDB(t, &extendedDatabaseManager{
+		DatabaseManager: dm,
+		dsn:             dsn,
+	})
+}
+
 type T interface {
 	TempDir() string
 }
 
 func initSQLiteDB(t T, maxConns int) (*extendedDatabaseManager, error) {
-	dsn := filepath.Join(t.TempDir(), testSQLiteDSN)
+	dsn := filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
 
 	dm, err := NewDatabaseManager(SQLite, dsn, maxConns)
 	if err != nil {

--- a/main/adapters/database/database_sqlite_test.go
+++ b/main/adapters/database/database_sqlite_test.go
@@ -595,6 +595,20 @@ func TestDatabaseManager_GetExternalIdentityUUIDs_sqlite(t *testing.T) {
 	}
 }
 
-func initSQLiteDB(t *testing.T, maxConns int) (*DatabaseManager, error) {
-	return NewDatabaseManager(SQLite, filepath.Join(t.TempDir(), testSQLiteDSN), maxConns)
+type T interface {
+	TempDir() string
+}
+
+func initSQLiteDB(t T, maxConns int) (*extendedDatabaseManager, error) {
+	dsn := filepath.Join(t.TempDir(), testSQLiteDSN)
+
+	dm, err := NewDatabaseManager(SQLite, dsn, maxConns)
+	if err != nil {
+		return nil, err
+	}
+
+	return &extendedDatabaseManager{
+		DatabaseManager: dm,
+		dsn:             dsn,
+	}, nil
 }

--- a/main/adapters/database/database_test.go
+++ b/main/adapters/database/database_test.go
@@ -663,6 +663,50 @@ func TestDatabaseManager_GetExternalIdentityUUIDs(t *testing.T) {
 	}
 }
 
+func TestDatabaseManager_NewDatabaseManager_DatabaseAlreadyOnLatestVersion(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
+	c, err := getConfig()
+	require.NoError(t, err)
+
+	// migrate database schema to the latest version
+	err = migrateUp(PostgreSQL, c.DbDSN)
+	require.NoError(t, err)
+
+	dm, err := NewDatabaseManager(PostgreSQL, c.DbDSN, 0)
+	assert.NoError(t, err)
+
+	cleanUpDB(t, &extendedDatabaseManager{
+		DatabaseManager: dm,
+		dsn:             c.DbDSN,
+	})
+}
+
+func TestDatabaseManager_NewDatabaseManager_DatabaseAlreadyExists(t *testing.T) {
+	// this test communicates with the actual postgres database
+	if testing.Short() {
+		t.Skipf("skipping integration test %s in short mode", t.Name())
+	}
+
+	c, err := getConfig()
+	require.NoError(t, err)
+
+	// migrate database schema to the latest version
+	err = migrateTo(PostgreSQL, c.DbDSN, 1)
+	require.NoError(t, err)
+
+	dm, err := NewDatabaseManager(PostgreSQL, c.DbDSN, 0)
+	assert.NoError(t, err)
+
+	cleanUpDB(t, &extendedDatabaseManager{
+		DatabaseManager: dm,
+		dsn:             c.DbDSN,
+	})
+}
+
 func getConfig() (*config.Config, error) {
 	configFileName := "config_test.json"
 	fileHandle, err := os.Open(filepath.Join("../../", configFileName))

--- a/main/adapters/database/migrate_sqlite_test.go
+++ b/main/adapters/database/migrate_sqlite_test.go
@@ -1,0 +1,55 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateUp_Sqlite(t *testing.T) {
+	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
+
+	// migrate database schema to the latest version
+	err := migrateUp(SQLite, dsn)
+	require.NoError(t, err)
+}
+
+func TestMigrateUp_Repeat_Sqlite(t *testing.T) {
+	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
+
+	// migrate database schema to the latest version
+	err := migrateUp(SQLite, dsn)
+	require.NoError(t, err)
+
+	// try to migrate database schema to the latest version again
+	err = migrateUp(SQLite, dsn)
+	require.NoError(t, err)
+}
+
+func TestMigrate_Sqlite(t *testing.T) {
+	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
+
+	err := migrateTo(SQLite, dsn, 1)
+	require.NoError(t, err)
+}
+
+func TestMigrateDown_Sqlite(t *testing.T) {
+	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
+
+	// migrate up first so we can migrate down from there
+	err := migrateUp(SQLite, dsn)
+	require.NoError(t, err)
+
+	err = migrateDown(SQLite, dsn)
+	require.NoError(t, err)
+}
+
+func TestMigrate_WrongDriver_Sqlite(t *testing.T) {
+	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
+
+	// migrate database schema to the latest version
+	err := migrateUp(PostgreSQL, dsn)
+	require.Error(t, err)
+}

--- a/main/adapters/database/migrate_test.go
+++ b/main/adapters/database/migrate_test.go
@@ -1,8 +1,6 @@
 package database
 
 import (
-	"database/sql"
-	"path/filepath"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -18,17 +16,8 @@ func TestMigrateUp_Postgres(t *testing.T) {
 	c, err := getConfig()
 	require.NoError(t, err)
 
-	db, err := sql.Open(PostgreSQL, c.DbDSN)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
 	// migrate database schema to the latest version
-	err = migrateUp(db, PostgreSQL)
+	err = migrateUp(PostgreSQL, c.DbDSN)
 	require.NoError(t, err)
 }
 
@@ -41,21 +30,12 @@ func TestMigrateUp_Repeat_Postgres(t *testing.T) {
 	c, err := getConfig()
 	require.NoError(t, err)
 
-	db, err := sql.Open(PostgreSQL, c.DbDSN)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
 	// migrate database schema to the latest version
-	err = migrateUp(db, PostgreSQL)
+	err = migrateUp(PostgreSQL, c.DbDSN)
 	require.NoError(t, err)
 
 	// try to migrate database schema to the latest version again
-	err = migrateUp(db, PostgreSQL)
+	err = migrateUp(PostgreSQL, c.DbDSN)
 	require.NoError(t, err)
 }
 
@@ -68,20 +48,11 @@ func TestMigrate_Postgres(t *testing.T) {
 	c, err := getConfig()
 	require.NoError(t, err)
 
-	db, err := sql.Open(PostgreSQL, c.DbDSN)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
-	err = migrateTo(db, PostgreSQL, 1)
+	err = migrateTo(PostgreSQL, c.DbDSN, 1)
 	require.NoError(t, err)
 }
 
-func TestMigrate_Down_Postgres(t *testing.T) {
+func TestMigrateDown_Postgres(t *testing.T) {
 	// this test communicates with the actual postgres database
 	if testing.Short() {
 		t.Skipf("skipping integration test %s in short mode", t.Name())
@@ -90,90 +61,7 @@ func TestMigrate_Down_Postgres(t *testing.T) {
 	c, err := getConfig()
 	require.NoError(t, err)
 
-	db, err := sql.Open(PostgreSQL, c.DbDSN)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
-	err = migrateDown(db, PostgreSQL)
-	require.NoError(t, err)
-}
-
-func TestMigrateUp_Sqlite(t *testing.T) {
-	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
-
-	db, err := sql.Open(SQLite, dsn)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
-	// migrate database schema to the latest version
-	err = migrateUp(db, SQLite)
-	require.NoError(t, err)
-}
-
-func TestMigrateUp_Repeat_Sqlite(t *testing.T) {
-	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
-
-	db, err := sql.Open(SQLite, dsn)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
-	// migrate database schema to the latest version
-	err = migrateUp(db, SQLite)
-	require.NoError(t, err)
-
-	// try to migrate database schema to the latest version again
-	err = migrateUp(db, SQLite)
-	require.NoError(t, err)
-}
-
-func TestMigrate_Sqlite(t *testing.T) {
-	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
-
-	db, err := sql.Open(SQLite, dsn)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
-	err = migrateTo(db, SQLite, 1)
-	require.NoError(t, err)
-}
-
-func TestMigrate_Down_Sqlite(t *testing.T) {
-	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
-
-	db, err := sql.Open(SQLite, dsn)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
-	// migrate up first so we can migrate down from there
-	err = migrateUp(db, SQLite)
-	require.NoError(t, err)
-
-	err = migrateDown(db, SQLite)
+	err = migrateDown(PostgreSQL, c.DbDSN)
 	require.NoError(t, err)
 }
 
@@ -186,32 +74,6 @@ func TestMigrate_WrongDriver_Postgres(t *testing.T) {
 	c, err := getConfig()
 	require.NoError(t, err)
 
-	db, err := sql.Open(PostgreSQL, c.DbDSN)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
-	err = migrateUp(db, SQLite)
-	require.Error(t, err)
-}
-
-func TestMigrate_WrongDriver_Sqlite(t *testing.T) {
-	var dsn = filepath.Join(t.TempDir(), testSQLiteDSN+sqliteConfig)
-
-	db, err := sql.Open(SQLite, dsn)
-	require.NoError(t, err)
-	defer func() {
-		err := db.Close()
-		if err != nil {
-			t.Error(err)
-		}
-	}()
-
-	// migrate database schema to the latest version
-	err = migrateUp(db, PostgreSQL)
+	err = migrateUp(SQLite, c.DbDSN)
 	require.Error(t, err)
 }

--- a/main/main.go
+++ b/main/main.go
@@ -48,7 +48,7 @@ func main() {
 		readinessChecks []func() error
 
 		// declare command-line flags
-		configDir = flag.String("configdirectory", "", "path to the configuration file")
+		configDir = flag.String("config-directory", "", "path to the configuration file")
 	)
 
 	// parse command-line flags

--- a/readme.db_migrations.md
+++ b/readme.db_migrations.md
@@ -1,0 +1,14 @@
+# Database Schema Migrations
+
+To update the database schema to a new version, create schema migration files for postgres and sqlite as described
+[here](https://github.com/golang-migrate/migrate/blob/master/MIGRATIONS.md).
+> all migrations must run within a transaction, so migration files must be wrapped with `BEGIN;` and `COMMIT;`
+> statements
+
+- postgreSQL migration files can be added
+  to [main/adapters/database/postgres/migrations](main/adapters/database/postgres/migrations)
+- SQLite migration files can be added
+  to [main/adapters/database/sqlite/migrations](main/adapters/database/sqlite/migrations)
+
+The migration will be executed automatically on application startup or can be triggered independently using a
+[CLI](https://github.com/golang-migrate/migrate/tree/master/cmd/migrate). 


### PR DESCRIPTION
**Added:**

- documentation on how to migrate database schema 

**Changed:**

- to set the configuration directory, the path to the configuration file now has to be passed as command line flag in the form `-config-directory path/to/configdir`